### PR TITLE
feat: add mirror map debuff and manual trigger UI

### DIFF
--- a/GoodWin.Debuffs.Easy/MirrorMapDebuff.cs
+++ b/GoodWin.Debuffs.Easy/MirrorMapDebuff.cs
@@ -1,0 +1,21 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+
+namespace GoodWin.Debuffs.Easy
+{
+    [DebuffSchedule(DebuffPhase.Easy, 4, 10, 60)]
+    public class MirrorMapDebuff : DebuffBase
+    {
+        public override string Name => "Отзеркалить карту";
+
+        public override void Apply()
+        {
+            CommandExecutor.ExecuteCommand("dota_minimap_position_option 1");
+        }
+
+        public override void Remove()
+        {
+            CommandExecutor.ExecuteCommand("dota_minimap_position_option 0");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Medium/ToxicChatDebuff.cs
+++ b/GoodWin.Debuffs.Medium/ToxicChatDebuff.cs
@@ -12,12 +12,19 @@ namespace GoodWin.Debuffs.Medium
     {
         public override string Name => "Токсичный чат";
 
-        private readonly string[] _lines = new[]
+        private readonly string[] _teamLines = new[]
         {
-            "You're trash!",
-            "Report this noob",
-            "Go feeders!",
-            "Learn to play!",
+            "Оу супергерой опять слил, как будто у тя не руки а мать шлюха",
+            "Спасибо что фидишь я бы без тебя не справился",
+            "Еблан",
+            "Уебмще, зачем тебе радик",
+        };
+
+        private readonly string[] _allLines = new[]
+        {
+            "Вы такие предсказуемые, что даже камень бы вас обыграл",
+            "Снесите уже, я не могу играть с ними",
+            "GG уроды, вы это проебали",
         };
 
         private CancellationTokenSource? _cts;
@@ -32,12 +39,18 @@ namespace GoodWin.Debuffs.Medium
                 var end = DateTime.UtcNow.AddSeconds(60);
                 while (!token.IsCancellationRequested && DateTime.UtcNow < end)
                 {
+                    bool team = rnd.Next(2) == 0;
                     InputHookHost.Instance.SendKey((int)Keys.Enter);
                     await Task.Delay(10, token);
-                    InputHookHost.Instance.SendKey((int)Keys.Tab);
-                    await Task.Delay(10, token);
+                    if (team)
+                    {
+                        InputHookHost.Instance.SendKey((int)Keys.Tab);
+                        await Task.Delay(10, token);
+                    }
 
-                    var msg = _lines[rnd.Next(_lines.Length)];
+                    var msg = team
+                        ? _teamLines[rnd.Next(_teamLines.Length)]
+                        : _allLines[rnd.Next(_allLines.Length)];
                     InputHookHost.Instance.SendText(msg);
                     InputHookHost.Instance.SendKey((int)Keys.Enter);
 

--- a/GoodWin.Gui/MainWindow.xaml
+++ b/GoodWin.Gui/MainWindow.xaml
@@ -55,10 +55,18 @@
                     <CheckBox Content="Easy" IsChecked="{Binding EasyEnabled}" />
                     <CheckBox Content="Medium" IsChecked="{Binding MediumEnabled}" />
                     <CheckBox Content="Hard" IsChecked="{Binding HardEnabled}" />
-                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                        <ComboBox Width="200" ItemsSource="{Binding AllDebuffs}" SelectedItem="{Binding SelectedDebuff}" DisplayMemberPath="Name" IsEnabled="{Binding AnyCategoryEnabled}" />
-                        <Button Content="Дебафф" Command="{Binding TestDebuffCommand}" Margin="5,0,0,0" IsEnabled="{Binding AnyCategoryEnabled}" />
-                    </StackPanel>
+                    <ListBox ItemsSource="{Binding AllDebuffs}" Margin="0,10,0,0" IsEnabled="{Binding AnyCategoryEnabled}">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{Binding Name}" Width="200"/>
+                                    <Button Content="Запустить"
+                                            Command="{Binding DataContext.RunDebuffCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                            CommandParameter="{Binding}" Margin="5,0,0,0"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                     <TextBlock Text="Путь к cfg" Margin="0,10,0,0" />
                     <StackPanel Orientation="Horizontal">
                         <TextBox Width="200" Text="{Binding ConfigPath}" />

--- a/GoodWin.Utils/CommandExecutor.cs
+++ b/GoodWin.Utils/CommandExecutor.cs
@@ -23,7 +23,7 @@ namespace GoodWin.Utils
 
         const uint INPUT_KEYBOARD = 1;
         const uint KEYEVENTF_KEYUP = 0x0002;
-        const ushort VK_OEM_3 = 0xC0; // '~'
+        const ushort VK_OEM_5 = 0xDC; // '\'
         const ushort VK_RETURN = 0x0D;
         const ushort VK_SHIFT = 0x10;
 
@@ -77,8 +77,8 @@ namespace GoodWin.Utils
                 });
             }
 
-            // open console '~'
-            Key(VK_OEM_3); Key(VK_OEM_3, true);
+            // open console '\'
+            Key(VK_OEM_5); Key(VK_OEM_5, true);
             // type command
             foreach (char c in command)
             {
@@ -93,7 +93,7 @@ namespace GoodWin.Utils
             // enter
             Key(VK_RETURN); Key(VK_RETURN, true);
             // close console
-            Key(VK_OEM_3); Key(VK_OEM_3, true);
+            Key(VK_OEM_5); Key(VK_OEM_5, true);
 
             SendInput((uint)inputs.Count, inputs.ToArray(), Marshal.SizeOf(typeof(INPUT)));
             SetForegroundWindow(prevWnd);


### PR DESCRIPTION
## Summary
- add mirror-map debuff using dota console commands
- expand toxic chat with russian lines and team/all logic
- rework UI to trigger each debuff directly and switch command executor to backslash

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" on linux)*

------
https://chatgpt.com/codex/tasks/task_e_6892d626543c8322a3096453ba84819b