### PR TITLE
feat: add new debuffs

### DIFF
--- a/GoodWin.Debuffs.Easy/BigCursorDebuff.cs
+++ b/GoodWin.Debuffs.Easy/BigCursorDebuff.cs
@@ -1,0 +1,25 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Easy
+{
+    [DebuffSchedule(DebuffPhase.Easy, 0, 999, 60)]
+    public class BigCursorDebuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "Большой курсор";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("cl_auto_cursor_scale 0");
+            InputHookHost.Instance.Cmd("cl_cursor_scale 30");
+            Console.WriteLine($"[BigCursor] applied for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("cl_cursor_scale 1");
+            InputHookHost.Instance.Cmd("cl_auto_cursor_scale 1");
+            Console.WriteLine("[BigCursor] restored");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Easy/Fps12Debuff.cs
+++ b/GoodWin.Debuffs.Easy/Fps12Debuff.cs
@@ -1,0 +1,23 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Easy
+{
+    [DebuffSchedule(DebuffPhase.Easy, 0, 999, 60)]
+    public class Fps12Debuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "FPS 12";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("fps_max 12");
+            Console.WriteLine($"[FPS12] limited for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("fps_max 120");
+            Console.WriteLine("[FPS12] restored");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Hard/CameraLockDebuff.cs
+++ b/GoodWin.Debuffs.Hard/CameraLockDebuff.cs
@@ -1,0 +1,25 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class CameraLockDebuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "Блокировка камеры";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("dota_camera_lock 1");
+            InputHookHost.Instance.SetCameraWheelBlocked(true);
+            Console.WriteLine($"[CameraLock] enabled for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("dota_camera_lock 0");
+            InputHookHost.Instance.SetCameraWheelBlocked(false);
+            Console.WriteLine("[CameraLock] disabled");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Hard/DisconnectDebuff.cs
+++ b/GoodWin.Debuffs.Hard/DisconnectDebuff.cs
@@ -1,0 +1,18 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 1)]
+    public class DisconnectDebuff : DebuffBase
+    {
+        public override string Name => "Дисконнект";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("disconnect");
+            Console.WriteLine("[Disconnect] command sent");
+        }
+        public override void Remove() { }
+    }
+}

--- a/GoodWin.Debuffs.Hard/FastSensitivityDebuff.cs
+++ b/GoodWin.Debuffs.Hard/FastSensitivityDebuff.cs
@@ -1,0 +1,43 @@
+using GoodWin.Core;
+using System;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class FastSensitivityDebuff : DebuffBase
+    {
+        private int _originalSpeed;
+        private const int Duration = 60;
+        public override string Name => "Быстрая сенса";
+        public override void Apply()
+        {
+            _originalSpeed = GetMouseSpeed();
+            int speed = 20; // maximum
+            SetMouseSpeed(speed);
+            Console.WriteLine($"[FastSens] speed set to {speed} for {Duration}s");
+        }
+        public override void Remove()
+        {
+            SetMouseSpeed(_originalSpeed);
+            Console.WriteLine("[FastSens] restored");
+        }
+
+        private const int SPI_GETMOUSESPEED = 0x0070;
+        private const int SPI_SETMOUSESPEED = 0x0071;
+
+        [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+        private static extern bool SystemParametersInfo(int uAction, int uParam, ref int lpvParam, int fuWinIni);
+
+        private static int GetMouseSpeed()
+        {
+            int speed = 0;
+            SystemParametersInfo(SPI_GETMOUSESPEED, 0, ref speed, 0);
+            return speed;
+        }
+
+        private static void SetMouseSpeed(int speed)
+        {
+            SystemParametersInfo(SPI_SETMOUSESPEED, 0, ref speed, 0);
+        }
+    }
+}

--- a/GoodWin.Debuffs.Hard/PingDebuff.cs
+++ b/GoodWin.Debuffs.Hard/PingDebuff.cs
@@ -1,0 +1,29 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class PingDebuff : DebuffBase
+    {
+        private readonly int _ping;
+        private const int Duration = 60;
+        public override string Name => "Высокий пинг";
+        public PingDebuff()
+        {
+            var arr = new[] { 200, 300, 400 };
+            _ping = arr[new Random().Next(arr.Length)];
+        }
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd($"net_fakelag {_ping}");
+            Console.WriteLine($"[Ping] fake lag {_ping}ms for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("net_fakelag 0");
+            Console.WriteLine("[Ping] restored");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Hard/SlowSensitivityDebuff.cs
+++ b/GoodWin.Debuffs.Hard/SlowSensitivityDebuff.cs
@@ -1,0 +1,43 @@
+using GoodWin.Core;
+using System;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class SlowSensitivityDebuff : DebuffBase
+    {
+        private int _originalSpeed;
+        private const int Duration = 60;
+        public override string Name => "Медленная сенса";
+        public override void Apply()
+        {
+            _originalSpeed = GetMouseSpeed();
+            int speed = 1; // minimum
+            SetMouseSpeed(speed);
+            Console.WriteLine($"[SlowSens] speed set to {speed} for {Duration}s");
+        }
+        public override void Remove()
+        {
+            SetMouseSpeed(_originalSpeed);
+            Console.WriteLine("[SlowSens] restored");
+        }
+
+        private const int SPI_GETMOUSESPEED = 0x0070;
+        private const int SPI_SETMOUSESPEED = 0x0071;
+
+        [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+        private static extern bool SystemParametersInfo(int uAction, int uParam, ref int lpvParam, int fuWinIni);
+
+        private static int GetMouseSpeed()
+        {
+            int speed = 0;
+            SystemParametersInfo(SPI_GETMOUSESPEED, 0, ref speed, 0);
+            return speed;
+        }
+
+        private static void SetMouseSpeed(int speed)
+        {
+            SystemParametersInfo(SPI_SETMOUSESPEED, 0, ref speed, 0);
+        }
+    }
+}

--- a/GoodWin.Debuffs.Medium/CameraReverseDebuff.cs
+++ b/GoodWin.Debuffs.Medium/CameraReverseDebuff.cs
@@ -1,0 +1,23 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Medium
+{
+    [DebuffSchedule(DebuffPhase.Medium, 0, 999, 60)]
+    public class CameraReverseDebuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "Инверсия камеры";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("dota_camera_reverse 1");
+            Console.WriteLine($"[CameraReverse] enabled for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("dota_camera_reverse 0");
+            Console.WriteLine("[CameraReverse] disabled");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Medium/HideCursorDebuff.cs
+++ b/GoodWin.Debuffs.Medium/HideCursorDebuff.cs
@@ -1,0 +1,23 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Medium
+{
+    [DebuffSchedule(DebuffPhase.Medium, 0, 999, 60)]
+    public class HideCursorDebuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "Скрыть курсор";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("dota_hide_cursor 1");
+            Console.WriteLine($"[HideCursor] hidden for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("dota_hide_cursor 0");
+            Console.WriteLine("[HideCursor] restored");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Medium/ViewportScaleDebuff.cs
+++ b/GoodWin.Debuffs.Medium/ViewportScaleDebuff.cs
@@ -1,0 +1,23 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Medium
+{
+    [DebuffSchedule(DebuffPhase.Medium, 0, 999, 60)]
+    public class ViewportScaleDebuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "Ужасное качество";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("mat_viewportscale 0.1");
+            Console.WriteLine($"[ViewportScale] 0.1 for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("mat_viewportscale 1");
+            Console.WriteLine("[ViewportScale] restored");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add multiple new debuffs including cursor scaling, FPS drop and camera lock
- allow blocking mouse wheel when camera is locked

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892ddb34b8c8322a46dc77bf267a3e4