### PR TITLE
feat: implement additional debuffs

### DIFF
--- a/GoodWin.Debuffs.Easy/BigCursorDebuff.cs
+++ b/GoodWin.Debuffs.Easy/BigCursorDebuff.cs
@@ -1,0 +1,25 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Easy
+{
+    [DebuffSchedule(DebuffPhase.Easy, 0, 999, 60)]
+    public class BigCursorDebuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "Большой курсор";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("cl_auto_cursor_scale 0");
+            InputHookHost.Instance.Cmd("cl_cursor_scale 30");
+            Console.WriteLine($"[BigCursor] applied for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("cl_cursor_scale 1");
+            InputHookHost.Instance.Cmd("cl_auto_cursor_scale 1");
+            Console.WriteLine("[BigCursor] restored");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Easy/BuyTeleportsDebuff.cs
+++ b/GoodWin.Debuffs.Easy/BuyTeleportsDebuff.cs
@@ -1,0 +1,19 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Easy
+{
+    [DebuffSchedule(DebuffPhase.Easy, 4, 10, 1)]
+    public class BuyTeleportsDebuff : DebuffBase
+    {
+        public override string Name => "Купить 5 ТП";
+        public override void Apply()
+        {
+            for (int i = 0; i < 5; i++)
+                InputHookHost.Instance.Cmd("dota_item_purchase item_tpscroll");
+            Console.WriteLine("[BuyTP] purchased 5 TP");
+        }
+        public override void Remove() { }
+    }
+}

--- a/GoodWin.Debuffs.Easy/Fps12Debuff.cs
+++ b/GoodWin.Debuffs.Easy/Fps12Debuff.cs
@@ -1,0 +1,23 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Easy
+{
+    [DebuffSchedule(DebuffPhase.Easy, 0, 999, 60)]
+    public class Fps12Debuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "FPS 12";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("fps_max 12");
+            Console.WriteLine($"[FPS12] limited for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("fps_max 120");
+            Console.WriteLine("[FPS12] restored");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Easy/HideMinimapDebuff.cs
+++ b/GoodWin.Debuffs.Easy/HideMinimapDebuff.cs
@@ -1,0 +1,31 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace GoodWin.Debuffs.Easy
+{
+    [DebuffSchedule(DebuffPhase.Easy, 4, 10, 60)]
+    public class HideMinimapDebuff : DebuffBase, IOverlayDebuff
+    {
+        private Guid _overlayId;
+        public override string Name => "Скрыть миникарту";
+        public override void Apply()
+        {
+            double size = 256;
+            double h = SystemParameters.PrimaryScreenHeight;
+            _overlayId = OverlayWindow.Instance.AddOverlay(dc =>
+            {
+                var brush = Brushes.Black;
+                dc.DrawRectangle(brush, null, new Rect(0, h - size, size, size));
+            });
+            Console.WriteLine("[HideMinimap] applied");
+        }
+        public override void Remove()
+        {
+            OverlayWindow.Instance.RemoveOverlay(_overlayId);
+            Console.WriteLine("[HideMinimap] removed");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Easy/TeleportHomeDebuff.cs
+++ b/GoodWin.Debuffs.Easy/TeleportHomeDebuff.cs
@@ -1,0 +1,18 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Easy
+{
+    [DebuffSchedule(DebuffPhase.Easy, 4, 10, 1)]
+    public class TeleportHomeDebuff : DebuffBase
+    {
+        public override string Name => "ТП домой";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("dota_item_use item_tpscroll");
+            Console.WriteLine("[TpHome] teleport home used");
+        }
+        public override void Remove() { }
+    }
+}

--- a/GoodWin.Debuffs.Hard/CameraLockDebuff.cs
+++ b/GoodWin.Debuffs.Hard/CameraLockDebuff.cs
@@ -1,0 +1,25 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class CameraLockDebuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "Блокировка камеры";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("dota_camera_lock 1");
+            InputHookHost.Instance.SetCameraWheelBlocked(true);
+            Console.WriteLine($"[CameraLock] enabled for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("dota_camera_lock 0");
+            InputHookHost.Instance.SetCameraWheelBlocked(false);
+            Console.WriteLine("[CameraLock] disabled");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Hard/CringeVoiceDebuff.cs
+++ b/GoodWin.Debuffs.Hard/CringeVoiceDebuff.cs
@@ -1,0 +1,18 @@
+using GoodWin.Core;
+using System.IO;
+using System.Media;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 5)]
+    public class CringeVoiceDebuff : DebuffBase, IAudioDebuff
+    {
+        public override string Name => "Кринж в войс";
+        public override void Apply()
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "Sounds", "cringe.wav");
+            try { using var player = new SoundPlayer(path); player.Play(); } catch { }
+        }
+        public override void Remove() { }
+    }
+}

--- a/GoodWin.Debuffs.Hard/DisconnectDebuff.cs
+++ b/GoodWin.Debuffs.Hard/DisconnectDebuff.cs
@@ -1,0 +1,18 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 1)]
+    public class DisconnectDebuff : DebuffBase
+    {
+        public override string Name => "Дисконнект";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("disconnect");
+            Console.WriteLine("[Disconnect] command sent");
+        }
+        public override void Remove() { }
+    }
+}

--- a/GoodWin.Debuffs.Hard/FakeTeammateVoiceDebuff.cs
+++ b/GoodWin.Debuffs.Hard/FakeTeammateVoiceDebuff.cs
@@ -1,0 +1,18 @@
+using GoodWin.Core;
+using System.IO;
+using System.Media;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 5)]
+    public class FakeTeammateVoiceDebuff : DebuffBase, IAudioDebuff
+    {
+        public override string Name => "Голос тиммейта";
+        public override void Apply()
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "Sounds", "fake_teammate.wav");
+            try { using var player = new SoundPlayer(path); player.Play(); } catch { }
+        }
+        public override void Remove() { }
+    }
+}

--- a/GoodWin.Debuffs.Hard/FastSensitivityDebuff.cs
+++ b/GoodWin.Debuffs.Hard/FastSensitivityDebuff.cs
@@ -1,0 +1,43 @@
+using GoodWin.Core;
+using System;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class FastSensitivityDebuff : DebuffBase
+    {
+        private int _originalSpeed;
+        private const int Duration = 60;
+        public override string Name => "Быстрая сенса";
+        public override void Apply()
+        {
+            _originalSpeed = GetMouseSpeed();
+            int speed = 20; // maximum
+            SetMouseSpeed(speed);
+            Console.WriteLine($"[FastSens] speed set to {speed} for {Duration}s");
+        }
+        public override void Remove()
+        {
+            SetMouseSpeed(_originalSpeed);
+            Console.WriteLine("[FastSens] restored");
+        }
+
+        private const int SPI_GETMOUSESPEED = 0x0070;
+        private const int SPI_SETMOUSESPEED = 0x0071;
+
+        [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+        private static extern bool SystemParametersInfo(int uAction, int uParam, ref int lpvParam, int fuWinIni);
+
+        private static int GetMouseSpeed()
+        {
+            int speed = 0;
+            SystemParametersInfo(SPI_GETMOUSESPEED, 0, ref speed, 0);
+            return speed;
+        }
+
+        private static void SetMouseSpeed(int speed)
+        {
+            SystemParametersInfo(SPI_SETMOUSESPEED, 0, ref speed, 0);
+        }
+    }
+}

--- a/GoodWin.Debuffs.Hard/MiniGameDebuff.cs
+++ b/GoodWin.Debuffs.Hard/MiniGameDebuff.cs
@@ -1,0 +1,56 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class MiniGameDebuff : DebuffBase
+    {
+        private Thread? _uiThread;
+        private Window? _window;
+        public override string Name => "Мини-игра";
+        public override void Apply()
+        {
+            InputHookHost.Instance.BlockAllKeys();
+            _uiThread = new Thread(() =>
+            {
+                _window = new Window
+                {
+                    Width = 300,
+                    Height = 200,
+                    WindowStartupLocation = WindowStartupLocation.CenterScreen,
+                    Topmost = true,
+                    ResizeMode = ResizeMode.NoResize,
+                    Title = "Мини-игра"
+                };
+                int clicks = 0;
+                var btn = new Button { Content = "Кликни 5 раз" };
+                btn.Click += (s, e) =>
+                {
+                    clicks++;
+                    btn.Content = $"Осталось {5 - clicks}";
+                    if (clicks >= 5)
+                        _window.Close();
+                };
+                _window.Content = btn;
+                _window.Closed += (s, e) => InputHookHost.Instance.UnblockAllKeys();
+                _window.ShowDialog();
+            });
+            _uiThread.SetApartmentState(ApartmentState.STA);
+            _uiThread.IsBackground = true;
+            _uiThread.Start();
+        }
+        public override void Remove()
+        {
+            if (_window != null)
+            {
+                _window.Dispatcher.Invoke(() => _window.Close());
+                _window = null;
+            }
+            InputHookHost.Instance.UnblockAllKeys();
+        }
+    }
+}

--- a/GoodWin.Debuffs.Hard/PingDebuff.cs
+++ b/GoodWin.Debuffs.Hard/PingDebuff.cs
@@ -1,0 +1,29 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class PingDebuff : DebuffBase
+    {
+        private readonly int _ping;
+        private const int Duration = 60;
+        public override string Name => "Высокий пинг";
+        public PingDebuff()
+        {
+            var arr = new[] { 200, 300, 400 };
+            _ping = arr[new Random().Next(arr.Length)];
+        }
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd($"net_fakelag {_ping}");
+            Console.WriteLine($"[Ping] fake lag {_ping}ms for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("net_fakelag 0");
+            Console.WriteLine("[Ping] restored");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Hard/PressAllItemsDebuff.cs
+++ b/GoodWin.Debuffs.Hard/PressAllItemsDebuff.cs
@@ -1,0 +1,19 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System.Windows.Forms;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 1)]
+    public class PressAllItemsDebuff : DebuffBase, IInputDebuff
+    {
+        public override string Name => "Прожать все предметы";
+        public override void Apply()
+        {
+            var keys = new[] { Keys.Z, Keys.X, Keys.C, Keys.V, Keys.B, Keys.N };
+            foreach (var k in keys)
+                InputHookHost.Instance.SendKey((int)k);
+        }
+        public override void Remove() { }
+    }
+}

--- a/GoodWin.Debuffs.Hard/PressAllSkillsDebuff.cs
+++ b/GoodWin.Debuffs.Hard/PressAllSkillsDebuff.cs
@@ -1,0 +1,19 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System.Windows.Forms;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 1)]
+    public class PressAllSkillsDebuff : DebuffBase, IInputDebuff
+    {
+        public override string Name => "Прожать все скилы";
+        public override void Apply()
+        {
+            var keys = new[] { Keys.Q, Keys.W, Keys.E, Keys.R, Keys.D, Keys.F };
+            foreach (var k in keys)
+                InputHookHost.Instance.SendKey((int)k);
+        }
+        public override void Remove() { }
+    }
+}

--- a/GoodWin.Debuffs.Hard/RainbowDebuff.cs
+++ b/GoodWin.Debuffs.Hard/RainbowDebuff.cs
@@ -1,0 +1,40 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class RainbowDebuff : DebuffBase, IOverlayDebuff
+    {
+        private Guid _overlayId;
+        public override string Name => "My Little Pony";
+        public override void Apply()
+        {
+            _overlayId = OverlayWindow.Instance.AddOverlay(dc =>
+            {
+                var rect = new Rect(0, 0, SystemParameters.PrimaryScreenWidth, SystemParameters.PrimaryScreenHeight);
+                var brush = new LinearGradientBrush();
+                brush.StartPoint = new Point(0, 0);
+                brush.EndPoint = new Point(1, 0);
+                brush.GradientStops.Add(new GradientStop(Colors.Red, 0));
+                brush.GradientStops.Add(new GradientStop(Colors.Orange, 0.17));
+                brush.GradientStops.Add(new GradientStop(Colors.Yellow, 0.33));
+                brush.GradientStops.Add(new GradientStop(Colors.Green, 0.5));
+                brush.GradientStops.Add(new GradientStop(Colors.Blue, 0.67));
+                brush.GradientStops.Add(new GradientStop(Colors.Indigo, 0.83));
+                brush.GradientStops.Add(new GradientStop(Colors.Violet, 1));
+                brush.Opacity = 0.5;
+                dc.DrawRectangle(brush, null, rect);
+            });
+            Console.WriteLine("[Rainbow] applied");
+        }
+        public override void Remove()
+        {
+            OverlayWindow.Instance.RemoveOverlay(_overlayId);
+            Console.WriteLine("[Rainbow] removed");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Hard/SlowSensitivityDebuff.cs
+++ b/GoodWin.Debuffs.Hard/SlowSensitivityDebuff.cs
@@ -1,0 +1,43 @@
+using GoodWin.Core;
+using System;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class SlowSensitivityDebuff : DebuffBase
+    {
+        private int _originalSpeed;
+        private const int Duration = 60;
+        public override string Name => "Медленная сенса";
+        public override void Apply()
+        {
+            _originalSpeed = GetMouseSpeed();
+            int speed = 1; // minimum
+            SetMouseSpeed(speed);
+            Console.WriteLine($"[SlowSens] speed set to {speed} for {Duration}s");
+        }
+        public override void Remove()
+        {
+            SetMouseSpeed(_originalSpeed);
+            Console.WriteLine("[SlowSens] restored");
+        }
+
+        private const int SPI_GETMOUSESPEED = 0x0070;
+        private const int SPI_SETMOUSESPEED = 0x0071;
+
+        [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+        private static extern bool SystemParametersInfo(int uAction, int uParam, ref int lpvParam, int fuWinIni);
+
+        private static int GetMouseSpeed()
+        {
+            int speed = 0;
+            SystemParametersInfo(SPI_GETMOUSESPEED, 0, ref speed, 0);
+            return speed;
+        }
+
+        private static void SetMouseSpeed(int speed)
+        {
+            SystemParametersInfo(SPI_SETMOUSESPEED, 0, ref speed, 0);
+        }
+    }
+}

--- a/GoodWin.Debuffs.Hard/Sounds/README.txt
+++ b/GoodWin.Debuffs.Hard/Sounds/README.txt
@@ -3,5 +3,7 @@ This directory should contain the following WAV files for audio debuffs:
 - keyboard_off.wav
 - keyboard_on.wav
 - pudge_hook.wav
+- fake_teammate.wav
+- cringe.wav
 
 Place the files with these exact names to enable sound playback.

--- a/GoodWin.Debuffs.Hard/ThirdPersonCameraDebuff.cs
+++ b/GoodWin.Debuffs.Hard/ThirdPersonCameraDebuff.cs
@@ -1,0 +1,27 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+using System.Windows.Forms;
+
+namespace GoodWin.Debuffs.Hard
+{
+    [DebuffSchedule(DebuffPhase.Hard, 0, 999, 60)]
+    public class ThirdPersonCameraDebuff : DebuffBase
+    {
+        public override string Name => "Камера от третьего лица";
+        public override void Apply()
+        {
+            InputHookHost.Instance.SendKey((int)Keys.I);
+            InputHookHost.Instance.Cmd("dota_camera_distance 2000");
+            InputHookHost.Instance.BlockKey((int)Keys.I);
+            Console.WriteLine("[ThirdPerson] enabled");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.UnblockKey((int)Keys.I);
+            InputHookHost.Instance.Cmd("dota_camera_distance 1134");
+            InputHookHost.Instance.SendKey((int)Keys.I);
+            Console.WriteLine("[ThirdPerson] disabled");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Medium/CameraReverseDebuff.cs
+++ b/GoodWin.Debuffs.Medium/CameraReverseDebuff.cs
@@ -1,0 +1,23 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Medium
+{
+    [DebuffSchedule(DebuffPhase.Medium, 0, 999, 60)]
+    public class CameraReverseDebuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "Инверсия камеры";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("dota_camera_reverse 1");
+            Console.WriteLine($"[CameraReverse] enabled for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("dota_camera_reverse 0");
+            Console.WriteLine("[CameraReverse] disabled");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Medium/HideCursorDebuff.cs
+++ b/GoodWin.Debuffs.Medium/HideCursorDebuff.cs
@@ -1,0 +1,23 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Medium
+{
+    [DebuffSchedule(DebuffPhase.Medium, 0, 999, 60)]
+    public class HideCursorDebuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "Скрыть курсор";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("dota_hide_cursor 1");
+            Console.WriteLine($"[HideCursor] hidden for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("dota_hide_cursor 0");
+            Console.WriteLine("[HideCursor] restored");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Medium/NarrowVisionDebuff.cs
+++ b/GoodWin.Debuffs.Medium/NarrowVisionDebuff.cs
@@ -1,0 +1,36 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace GoodWin.Debuffs.Medium
+{
+    [DebuffSchedule(DebuffPhase.Medium, 10, 15, 60)]
+    public class NarrowVisionDebuff : DebuffBase, IOverlayDebuff
+    {
+        private Guid _overlayId;
+        public override string Name => "Сузить обзор";
+        public override void Apply()
+        {
+            _overlayId = OverlayWindow.Instance.AddOverlay(dc =>
+            {
+                double w = SystemParameters.PrimaryScreenWidth;
+                double h = SystemParameters.PrimaryScreenHeight;
+                double marginX = w * 0.2;
+                double marginY = h * 0.2;
+                var brush = Brushes.Black;
+                dc.DrawRectangle(brush, null, new Rect(0, 0, w, marginY));
+                dc.DrawRectangle(brush, null, new Rect(0, h - marginY, w, marginY));
+                dc.DrawRectangle(brush, null, new Rect(0, marginY, marginX, h - 2 * marginY));
+                dc.DrawRectangle(brush, null, new Rect(w - marginX, marginY, marginX, h - 2 * marginY));
+            });
+            Console.WriteLine("[NarrowVision] applied");
+        }
+        public override void Remove()
+        {
+            OverlayWindow.Instance.RemoveOverlay(_overlayId);
+            Console.WriteLine("[NarrowVision] removed");
+        }
+    }
+}

--- a/GoodWin.Debuffs.Medium/ViewportScaleDebuff.cs
+++ b/GoodWin.Debuffs.Medium/ViewportScaleDebuff.cs
@@ -1,0 +1,23 @@
+using GoodWin.Core;
+using GoodWin.Utils;
+using System;
+
+namespace GoodWin.Debuffs.Medium
+{
+    [DebuffSchedule(DebuffPhase.Medium, 0, 999, 60)]
+    public class ViewportScaleDebuff : DebuffBase
+    {
+        private const int Duration = 60;
+        public override string Name => "Ужасное качество";
+        public override void Apply()
+        {
+            InputHookHost.Instance.Cmd("mat_viewportscale 0.1");
+            Console.WriteLine($"[ViewportScale] 0.1 for {Duration}s");
+        }
+        public override void Remove()
+        {
+            InputHookHost.Instance.Cmd("mat_viewportscale 1");
+            Console.WriteLine("[ViewportScale] restored");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add debuffs for narrowed view, minimap hiding, and mass ability/item use
- introduce mini game, rainbow overlay, third-person camera, audio pranks, and teleport effects
- document new audio resources for voice debuffs

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892ddb34b8c8322a46dc77bf267a3e4