### PR TITLE
Fix timer ambiguity and optimize debuff mechanics

### DIFF
--- a/GoodWin.Debuffs.Easy/Fps12Debuff.cs
+++ b/GoodWin.Debuffs.Easy/Fps12Debuff.cs
@@ -1,6 +1,8 @@
 using GoodWin.Core;
 using GoodWin.Utils;
 using System;
+using System.IO;
+using System.Linq;
 
 namespace GoodWin.Debuffs.Easy
 {
@@ -8,16 +10,40 @@ namespace GoodWin.Debuffs.Easy
     public class Fps12Debuff : DebuffBase
     {
         private const int Duration = 60;
+        private string? _prevFps;
         public override string Name => "FPS 12";
         public override void Apply()
         {
+            _prevFps = ReadCurrentFps() ?? "120";
             InputHookHost.Instance.Cmd("fps_max 12");
             Console.WriteLine($"[FPS12] limited for {Duration}s");
         }
         public override void Remove()
         {
-            InputHookHost.Instance.Cmd("fps_max 120");
+            var value = _prevFps ?? "120";
+            InputHookHost.Instance.Cmd($"fps_max {value}");
             Console.WriteLine("[FPS12] restored");
+        }
+
+        private string? ReadCurrentFps()
+        {
+            try
+            {
+                var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                    "Dota 2", "cfg", "video.txt");
+                if (File.Exists(path))
+                {
+                    var line = File.ReadLines(path).FirstOrDefault(l => l.Contains("fps_max"));
+                    if (line != null)
+                    {
+                        var parts = line.Split('"');
+                        if (parts.Length >= 2)
+                            return parts[1];
+                    }
+                }
+            }
+            catch { }
+            return null;
         }
     }
 }

--- a/GoodWin.Debuffs.Hard/MiniGameDebuff.cs
+++ b/GoodWin.Debuffs.Hard/MiniGameDebuff.cs
@@ -50,6 +50,11 @@ namespace GoodWin.Debuffs.Hard
                 _window.Dispatcher.Invoke(() => _window.Close());
                 _window = null;
             }
+            if (_uiThread != null)
+            {
+                _uiThread.Join();
+                _uiThread = null;
+            }
             InputHookHost.Instance.UnblockAllKeys();
         }
     }

--- a/GoodWin.Debuffs.Hard/PressAllItemsDebuff.cs
+++ b/GoodWin.Debuffs.Hard/PressAllItemsDebuff.cs
@@ -1,5 +1,6 @@
 using GoodWin.Core;
 using GoodWin.Utils;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace GoodWin.Debuffs.Hard
@@ -12,7 +13,10 @@ namespace GoodWin.Debuffs.Hard
         {
             var keys = new[] { Keys.Z, Keys.X, Keys.C, Keys.V, Keys.B, Keys.N };
             foreach (var k in keys)
+            {
                 InputHookHost.Instance.SendKey((int)k);
+                Thread.Sleep(50);
+            }
         }
         public override void Remove() { }
     }

--- a/GoodWin.Debuffs.Hard/PressAllSkillsDebuff.cs
+++ b/GoodWin.Debuffs.Hard/PressAllSkillsDebuff.cs
@@ -1,5 +1,6 @@
 using GoodWin.Core;
 using GoodWin.Utils;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace GoodWin.Debuffs.Hard
@@ -12,7 +13,10 @@ namespace GoodWin.Debuffs.Hard
         {
             var keys = new[] { Keys.Q, Keys.W, Keys.E, Keys.R, Keys.D, Keys.F };
             foreach (var k in keys)
+            {
                 InputHookHost.Instance.SendKey((int)k);
+                Thread.Sleep(50);
+            }
         }
         public override void Remove() { }
     }

--- a/GoodWin.Debuffs.Hard/ThirdPersonCameraDebuff.cs
+++ b/GoodWin.Debuffs.Hard/ThirdPersonCameraDebuff.cs
@@ -1,6 +1,8 @@
 using GoodWin.Core;
 using GoodWin.Utils;
 using System;
+using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace GoodWin.Debuffs.Hard
@@ -9,8 +11,10 @@ namespace GoodWin.Debuffs.Hard
     public class ThirdPersonCameraDebuff : DebuffBase
     {
         public override string Name => "Камера от третьего лица";
+        private string? _prevDistance;
         public override void Apply()
         {
+            _prevDistance = ReadCurrentDistance() ?? "1134";
             InputHookHost.Instance.SendKey((int)Keys.I);
             InputHookHost.Instance.Cmd("dota_camera_distance 2000");
             InputHookHost.Instance.BlockKey((int)Keys.I);
@@ -19,9 +23,31 @@ namespace GoodWin.Debuffs.Hard
         public override void Remove()
         {
             InputHookHost.Instance.UnblockKey((int)Keys.I);
-            InputHookHost.Instance.Cmd("dota_camera_distance 1134");
+            var value = _prevDistance ?? "1134";
+            InputHookHost.Instance.Cmd($"dota_camera_distance {value}");
             InputHookHost.Instance.SendKey((int)Keys.I);
             Console.WriteLine("[ThirdPerson] disabled");
+        }
+
+        private string? ReadCurrentDistance()
+        {
+            try
+            {
+                var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                    "Dota 2", "cfg", "config.cfg");
+                if (File.Exists(path))
+                {
+                    var line = File.ReadLines(path).FirstOrDefault(l => l.Contains("dota_camera_distance"));
+                    if (line != null)
+                    {
+                        var parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length >= 2)
+                            return parts[^1];
+                    }
+                }
+            }
+            catch { }
+            return null;
         }
     }
 }

--- a/GoodWin.Debuffs.Medium/AutoSkillDebuff.cs
+++ b/GoodWin.Debuffs.Medium/AutoSkillDebuff.cs
@@ -8,18 +8,22 @@ namespace GoodWin.Debuffs.Medium
     public class AutoSkillDebuff : DebuffBase, IInputDebuff
     {
         private readonly InputSimulator _sim = new InputSimulator();
-        private readonly string _slot1, _slot3;
+        private readonly VirtualKeyCode? _key1;
+        private readonly VirtualKeyCode? _key3;
         public override string Name => "ПЕРВЫЙ СКИЛЛ И ТРЕТИЙ";
         public AutoSkillDebuff(string slot1, string slot3)
         {
-            _slot1 = slot1; _slot3 = slot3;
+            if (Enum.TryParse("VK_" + slot1, out VirtualKeyCode key1))
+                _key1 = key1;
+            if (Enum.TryParse("VK_" + slot3, out VirtualKeyCode key3))
+                _key3 = key3;
         }
         public override void Apply()
         {
-            if (Enum.TryParse("VK_" + _slot1, out VirtualKeyCode key1))
-                _sim.Keyboard.KeyPress(key1);
-            if (Enum.TryParse("VK_" + _slot3, out VirtualKeyCode key3))
-                _sim.Keyboard.KeyPress(key3);
+            if (_key1.HasValue)
+                _sim.Keyboard.KeyPress(_key1.Value);
+            if (_key3.HasValue)
+                _sim.Keyboard.KeyPress(_key3.Value);
         }
         public override void Remove() { }
     }

--- a/GoodWin.Tracker/ScreenCaptureService.cs
+++ b/GoodWin.Tracker/ScreenCaptureService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Threading;
 using System.Windows.Forms;
+using Timer = System.Threading.Timer;
 
 namespace GoodWin.Tracker
 {

--- a/GoodWin.Utils/InputHookHost.cs
+++ b/GoodWin.Utils/InputHookHost.cs
@@ -164,9 +164,13 @@ namespace GoodWin.Utils
         private void SendConsoleCommand(string cmd)
         {
             const byte CK = 0xDC;
-            SendKey(CK); Thread.Sleep(5);
-            SendText(cmd); Thread.Sleep(5);
-            SendKey((int)Keys.Enter); Thread.Sleep(5);
+            const int Delay = 1;
+            SendKey(CK);
+            Thread.Sleep(Delay);
+            SendText(cmd);
+            Thread.Sleep(Delay);
+            SendKey((int)Keys.Enter);
+            Thread.Sleep(Delay);
             SendKey(CK);
         }
 


### PR DESCRIPTION
## Summary
- fix Timer type ambiguity in screen capture service
- improve debuff mechanics: faster console commands, cached key codes, delays and state restoration
- ensure mini game debuff cleans up its UI thread

## Testing
- `dotnet build -r win-x64 -p:EnableWindowsTargeting=true` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*


------
https://chatgpt.com/codex/tasks/task_e_6892e3e8d3c8832284ac6aa2dfdab1a3