### PR TITLE
feat(gui): apply dark theme resources

### DIFF
--- a/GoodWin.Gui/App.xaml
+++ b/GoodWin.Gui/App.xaml
@@ -3,5 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Themes/DarkTheme.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/GoodWin.Gui/MainWindow.xaml
+++ b/GoodWin.Gui/MainWindow.xaml
@@ -7,38 +7,9 @@
         xmlns:views="clr-namespace:GoodWin.Gui.Views"
         xmlns:conv="clr-namespace:GoodWin.Gui.Converters"
         mc:Ignorable="d"
-        Title="GoodWin Debuff" Height="600" Width="800"
-        Background="{DynamicResource DarkBackground}"
-        Foreground="{DynamicResource LightForeground}">
+        Title="GoodWin Debuff" Height="600" Width="800">
     <Window.Resources>
-        <SolidColorBrush x:Key="DarkBackground" Color="#1E1E1E" />
-        <SolidColorBrush x:Key="LightBackground" Color="#2E2E2E" />
-        <SolidColorBrush x:Key="LightForeground" Color="White" />
         <conv:BoolInvertVisibilityConverter x:Key="BoolInvertVisibilityConverter" />
-        <Style TargetType="TabControl">
-            <Setter Property="Background" Value="{StaticResource DarkBackground}" />
-            <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
-        </Style>
-        <Style TargetType="TabItem">
-            <Setter Property="Background" Value="{StaticResource DarkBackground}" />
-            <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
-        </Style>
-        <Style TargetType="TextBox">
-            <Setter Property="Background" Value="{StaticResource LightBackground}" />
-            <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
-        </Style>
-        <Style TargetType="ComboBox">
-            <Setter Property="Background" Value="{StaticResource LightBackground}" />
-            <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
-        </Style>
-        <Style TargetType="ListBox">
-            <Setter Property="Background" Value="{StaticResource LightBackground}" />
-            <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
-        </Style>
-        <Style TargetType="Button">
-            <Setter Property="Background" Value="{StaticResource LightBackground}" />
-            <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
-        </Style>
     </Window.Resources>
     <Window.DataContext>
         <vm:MainViewModel />
@@ -52,9 +23,9 @@
                 </Grid.ColumnDefinitions>
                 <StackPanel>
                     <TextBlock Text="Категории дебаффов" FontWeight="Bold" />
-                    <CheckBox Content="Easy" IsChecked="{Binding EasyEnabled}" />
-                    <CheckBox Content="Medium" IsChecked="{Binding MediumEnabled}" />
-                    <CheckBox Content="Hard" IsChecked="{Binding HardEnabled}" />
+                    <CheckBox Content="Легкий" IsChecked="{Binding EasyEnabled}" />
+                    <CheckBox Content="Средний" IsChecked="{Binding MediumEnabled}" />
+                    <CheckBox Content="Сложный" IsChecked="{Binding HardEnabled}" />
                     <ListBox ItemsSource="{Binding AllDebuffs}" Margin="0,10,0,0" IsEnabled="{Binding AnyCategoryEnabled}">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
@@ -87,7 +58,7 @@
         <TabItem Header="Настройки">
             <views:SettingsView />
         </TabItem>
-        <TabItem Header="Debug">
+        <TabItem Header="Отладка">
             <Grid Margin="10">
                 <ListBox ItemsSource="{Binding DebugLog}" />
             </Grid>

--- a/GoodWin.Gui/Themes/DarkTheme.xaml
+++ b/GoodWin.Gui/Themes/DarkTheme.xaml
@@ -1,0 +1,91 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Цвета -->
+    <SolidColorBrush x:Key="DarkBackground" Color="#1E1E1E" />
+    <SolidColorBrush x:Key="LightBackground" Color="#2E2E2E" />
+    <SolidColorBrush x:Key="LightForeground" Color="White" />
+    <SolidColorBrush x:Key="AccentBrush" Color="#FF8C00" />
+
+    <!-- Общие стили -->
+    <Style TargetType="{x:Type Control}">
+        <Setter Property="FontFamily" Value="Segoe UI" />
+        <Setter Property="FontSize" Value="14" />
+    </Style>
+
+    <Style TargetType="UserControl">
+        <Setter Property="Background" Value="{StaticResource DarkBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
+    </Style>
+    <Style TargetType="Window">
+        <Setter Property="Background" Value="{StaticResource DarkBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
+    </Style>
+
+    <Style TargetType="TabControl">
+        <Setter Property="Background" Value="{StaticResource DarkBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
+    </Style>
+
+    <Style TargetType="TabItem">
+        <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TabItem">
+                    <Border x:Name="border" Background="{StaticResource DarkBackground}" Padding="10,5" CornerRadius="4">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{StaticResource AccentBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{StaticResource LightBackground}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="TextBox">
+        <Setter Property="Background" Value="{StaticResource LightBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="4" />
+    </Style>
+
+    <Style TargetType="ComboBox">
+        <Setter Property="Background" Value="{StaticResource LightBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
+    </Style>
+
+    <Style TargetType="ListBox">
+        <Setter Property="Background" Value="{StaticResource LightBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
+    </Style>
+
+    <Style TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource LightBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource LightForeground}" />
+        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="4">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{StaticResource AccentBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{StaticResource LightBackground}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/GoodWin.Gui/Views/DebuffNotificationWindow.xaml
+++ b/GoodWin.Gui/Views/DebuffNotificationWindow.xaml
@@ -3,8 +3,9 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         WindowStyle="None"
         AllowsTransparency="True"
-        Background="#CC000000"
-        Foreground="White"
+        Background="{DynamicResource DarkBackground}"
+        Foreground="{DynamicResource LightForeground}"
+        Opacity="0.8"
         Width="300" Height="120"
         Topmost="True"
         ShowInTaskbar="False">


### PR DESCRIPTION
## Summary
- add centralized dark theme dictionary with accent color and modern control styles
- localize main window categories and debug tab to Russian
- align notification window with the new theme resources

## Testing
- `dotnet build GoodWinDebuff.sln -p:EnableWindowsTargeting=true` *(fails: Could not resolve SDK Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_6892ebd4eb20832281b31c4d891576c7