### PR TITLE
feat(gui): add animations and center layout

### DIFF
--- a/GoodWin.Gui/MainWindow.xaml
+++ b/GoodWin.Gui/MainWindow.xaml
@@ -7,61 +7,78 @@
         xmlns:views="clr-namespace:GoodWin.Gui.Views"
         xmlns:conv="clr-namespace:GoodWin.Gui.Converters"
         mc:Ignorable="d"
-        Title="GoodWin Debuff" Height="600" Width="800">
+        Title="GoodWin Debuff" Height="600" Width="800" WindowStartupLocation="CenterScreen">
     <Window.Resources>
         <conv:BoolInvertVisibilityConverter x:Key="BoolInvertVisibilityConverter" />
     </Window.Resources>
     <Window.DataContext>
         <vm:MainViewModel />
     </Window.DataContext>
+    <Window.Triggers>
+        <EventTrigger RoutedEvent="Window.Loaded">
+            <BeginStoryboard>
+                <Storyboard>
+                    <DoubleAnimation Storyboard.TargetProperty="Opacity" From="0" To="1" Duration="0:0:0.3" />
+                </Storyboard>
+            </BeginStoryboard>
+        </EventTrigger>
+    </Window.Triggers>
     <TabControl>
         <TabItem Header="Главное">
-            <Grid Margin="10">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <StackPanel>
-                    <TextBlock Text="Категории дебаффов" FontWeight="Bold" />
-                    <CheckBox Content="Легкий" IsChecked="{Binding EasyEnabled}" />
-                    <CheckBox Content="Средний" IsChecked="{Binding MediumEnabled}" />
-                    <CheckBox Content="Сложный" IsChecked="{Binding HardEnabled}" />
-                    <ListBox ItemsSource="{Binding AllDebuffs}" Margin="0,10,0,0" IsEnabled="{Binding AnyCategoryEnabled}">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="{Binding Name}" Width="200"/>
-                                    <Button Content="Запустить"
-                                            Command="{Binding DataContext.RunDebuffCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
-                                            CommandParameter="{Binding}" Margin="5,0,0,0"/>
-                                </StackPanel>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                    <TextBlock Text="Путь к cfg" Margin="0,10,0,0" />
-                    <StackPanel Orientation="Horizontal">
-                        <TextBox Width="200" Text="{Binding ConfigPath}" />
-                        <Button Content="..." Command="{Binding BrowseConfigCommand}" Margin="5,0,0,0" />
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <Grid Margin="20" HorizontalAlignment="Center">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel HorizontalAlignment="Center">
+                        <TextBlock Text="Категории дебаффов" FontWeight="Bold" HorizontalAlignment="Center" />
+                        <CheckBox Content="Легкий" IsChecked="{Binding EasyEnabled}" HorizontalAlignment="Center" />
+                        <CheckBox Content="Средний" IsChecked="{Binding MediumEnabled}" HorizontalAlignment="Center" />
+                        <CheckBox Content="Сложный" IsChecked="{Binding HardEnabled}" HorizontalAlignment="Center" />
+                        <ListBox ItemsSource="{Binding AllDebuffs}" Margin="0,10,0,0" IsEnabled="{Binding AnyCategoryEnabled}" HorizontalAlignment="Center" Width="300" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Margin="0,5">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="{Binding Name}" Grid.Column="0" Margin="0,0,10,0" />
+                                        <Button Content="Запустить"
+                                                Command="{Binding DataContext.RunDebuffCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                                CommandParameter="{Binding}" Grid.Column="1" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                        <TextBlock Text="Путь к cfg" Margin="0,10,0,0" HorizontalAlignment="Center" />
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBox Width="200" Text="{Binding ConfigPath}" />
+                            <Button Content="..." Command="{Binding BrowseConfigCommand}" Margin="5,0,0,0" />
+                        </StackPanel>
+                        <Button Content="Инициализировать конфиг" Command="{Binding InitConfigCommand}" Margin="0,5,0,0" HorizontalAlignment="Center" />
+                        <Button Content="Инициализировать команды" Command="{Binding InitCommandsCommand}" Margin="0,5,0,0" IsEnabled="{Binding CanInitCommands}" HorizontalAlignment="Center" />
                     </StackPanel>
-                    <Button Content="Инициализировать конфиг" Command="{Binding InitConfigCommand}" Margin="0,5,0,0" />
-                    <Button Content="Инициализировать команды" Command="{Binding InitCommandsCommand}" Margin="0,5,0,0" IsEnabled="{Binding CanInitCommands}" />
-                </StackPanel>
-                <StackPanel Grid.Column="1">
-                    <TextBlock Text="Лог событий" FontWeight="Bold" />
-                    <ListBox ItemsSource="{Binding EventLog}" Height="200" />
-                    <TextBlock Text="{Binding GsiStatus}" Margin="0,10,0,0" />
-                    <Button Content="Запустить Dota 2" Command="{Binding StartDotaCommand}" Visibility="{Binding IsDotaRunning, Converter={StaticResource BoolInvertVisibilityConverter}}" Margin="0,5,0,0" />
-                    <CheckBox Content="Проверить отслеживание героя" IsChecked="{Binding IsHeroTrackingEnabled}" Margin="0,5,0,0" />
-                </StackPanel>
-            </Grid>
+                    <StackPanel Grid.Column="1" HorizontalAlignment="Center">
+                        <TextBlock Text="Лог событий" FontWeight="Bold" HorizontalAlignment="Center" />
+                        <ListBox ItemsSource="{Binding EventLog}" Height="200" Width="250" />
+                        <TextBlock Text="{Binding GsiStatus}" Margin="0,10,0,0" HorizontalAlignment="Center" />
+                        <Button Content="Запустить Dota 2" Command="{Binding StartDotaCommand}" Visibility="{Binding IsDotaRunning,Converter={StaticResource BoolInvertVisibilityConverter}}" Margin="0,5,0,0" HorizontalAlignment="Center" />
+                        <CheckBox Content="Проверить отслеживание героя" IsChecked="{Binding IsHeroTrackingEnabled}" Margin="0,5,0,0" HorizontalAlignment="Center" />
+                    </StackPanel>
+                </Grid>
+            </ScrollViewer>
         </TabItem>
         <TabItem Header="Настройки">
             <views:SettingsView />
         </TabItem>
         <TabItem Header="Отладка">
-            <Grid Margin="10">
-                <ListBox ItemsSource="{Binding DebugLog}" />
-            </Grid>
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <Grid Margin="10" HorizontalAlignment="Center">
+                    <ListBox ItemsSource="{Binding DebugLog}" Width="400" />
+                </Grid>
+            </ScrollViewer>
         </TabItem>
     </TabControl>
 </Window>

--- a/GoodWin.Gui/Themes/DarkTheme.xaml
+++ b/GoodWin.Gui/Themes/DarkTheme.xaml
@@ -70,6 +70,12 @@
         <Setter Property="Padding" Value="8,4" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="RenderTransformOrigin" Value="0.5,0.5" />
+        <Setter Property="RenderTransform">
+            <Setter.Value>
+                <ScaleTransform ScaleX="1" ScaleY="1" />
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -87,5 +93,39 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Style.Triggers>
+            <EventTrigger RoutedEvent="MouseEnter">
+                <BeginStoryboard>
+                    <Storyboard>
+                        <DoubleAnimation Storyboard.TargetProperty="(RenderTransform).(ScaleTransform.ScaleX)" To="1.05" Duration="0:0:0.1" />
+                        <DoubleAnimation Storyboard.TargetProperty="(RenderTransform).(ScaleTransform.ScaleY)" To="1.05" Duration="0:0:0.1" />
+                    </Storyboard>
+                </BeginStoryboard>
+            </EventTrigger>
+            <EventTrigger RoutedEvent="MouseLeave">
+                <BeginStoryboard>
+                    <Storyboard>
+                        <DoubleAnimation Storyboard.TargetProperty="(RenderTransform).(ScaleTransform.ScaleX)" To="1" Duration="0:0:0.1" />
+                        <DoubleAnimation Storyboard.TargetProperty="(RenderTransform).(ScaleTransform.ScaleY)" To="1" Duration="0:0:0.1" />
+                    </Storyboard>
+                </BeginStoryboard>
+            </EventTrigger>
+            <EventTrigger RoutedEvent="PreviewMouseDown">
+                <BeginStoryboard>
+                    <Storyboard>
+                        <DoubleAnimation Storyboard.TargetProperty="(RenderTransform).(ScaleTransform.ScaleX)" To="0.95" Duration="0:0:0.05" />
+                        <DoubleAnimation Storyboard.TargetProperty="(RenderTransform).(ScaleTransform.ScaleY)" To="0.95" Duration="0:0:0.05" />
+                    </Storyboard>
+                </BeginStoryboard>
+            </EventTrigger>
+            <EventTrigger RoutedEvent="PreviewMouseUp">
+                <BeginStoryboard>
+                    <Storyboard>
+                        <DoubleAnimation Storyboard.TargetProperty="(RenderTransform).(ScaleTransform.ScaleX)" To="1.05" Duration="0:0:0.05" />
+                        <DoubleAnimation Storyboard.TargetProperty="(RenderTransform).(ScaleTransform.ScaleY)" To="1.05" Duration="0:0:0.05" />
+                    </Storyboard>
+                </BeginStoryboard>
+            </EventTrigger>
+        </Style.Triggers>
     </Style>
 </ResourceDictionary>

--- a/GoodWin.Gui/Views/SettingsView.xaml
+++ b/GoodWin.Gui/Views/SettingsView.xaml
@@ -5,8 +5,9 @@
     <UserControl.DataContext>
         <vm:SettingsViewModel />
     </UserControl.DataContext>
-    <StackPanel Margin="10">
-        <Grid>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="10" HorizontalAlignment="Center">
+            <Grid HorizontalAlignment="Center">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="200" />
                 <ColumnDefinition Width="200" />
@@ -53,14 +54,15 @@
             <TextBlock Text="Общий чат" Grid.Row="12" />
             <TextBox Text="{Binding TeamChatKey}" Grid.Column="1" Grid.Row="12" />
         </Grid>
-        <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-            <TextBlock Text="Путь к config-файлу" VerticalAlignment="Center" />
-            <TextBox Text="{Binding ConfigPath}" Width="200" Margin="5,0,0,0" />
-            <Button Content="Обзор..." Command="{Binding BrowseConfigCommand}" Margin="5,0,0,0" />
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Center">
+                <TextBlock Text="Путь к config-файлу" VerticalAlignment="Center" />
+                <TextBox Text="{Binding ConfigPath}" Width="200" Margin="5,0,0,0" />
+                <Button Content="Обзор..." Command="{Binding BrowseConfigCommand}" Margin="5,0,0,0" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Center">
+                <Button Content="Сохранить" Command="{Binding SaveCommand}" Width="100" />
+                <Button Content="Сбросить" Command="{Binding ResetCommand}" Width="100" Margin="5,0,0,0" />
+            </StackPanel>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-            <Button Content="Сохранить" Command="{Binding SaveCommand}" Width="100" />
-            <Button Content="Сбросить" Command="{Binding ResetCommand}" Width="100" Margin="5,0,0,0" />
-        </StackPanel>
-    </StackPanel>
+    </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
## Summary
- animate buttons for a livelier dark theme
- center main window content with fade-in effect
- wrap settings in scroll viewers to prevent overflow

## Testing
- `dotnet build` *(fails: NETSDK1100 - EnableWindowsTargeting)*

------
https://chatgpt.com/codex/tasks/task_e_6892edf67d408322b22400929760b386