### PR TITLE
fix: restore navigation layout and content styling

### DIFF
--- a/GoodWin.Gui/MainWindow.xaml
+++ b/GoodWin.Gui/MainWindow.xaml
@@ -21,10 +21,13 @@
                                 <ColumnDefinition Width="240" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <StackPanel Grid.Column="0" Background="{StaticResource NavBackground}" VerticalAlignment="Center">
-                                <TabPanel x:Name="HeaderPanel" IsItemsHost="True" Background="{StaticResource NavBackground}" />
-                            </StackPanel>
-                            <Border Grid.Column="1" Background="{StaticResource AppBackground}" Padding="24,0,32,0">
+                            <Border Grid.Column="0" Background="{StaticResource NavBackground}">
+                                <TabPanel x:Name="HeaderPanel"
+                                          IsItemsHost="True"
+                                          Background="{StaticResource NavBackground}"
+                                          VerticalAlignment="Center" />
+                            </Border>
+                            <Border Grid.Column="1" Background="{StaticResource AppBackground}" Padding="24,16,32,16">
                                 <ContentPresenter x:Name="PART_SelectedContentHost" />
                             </Border>
                         </Grid>
@@ -38,11 +41,16 @@
 
         <Style TargetType="TabItem">
             <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+            <Setter Property="FontSize" Value="16" />
+            <Setter Property="Height" Value="48" />
+            <Setter Property="Margin" Value="0,8" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="TabItem">
-                        <Border x:Name="Bd" Background="Transparent" Padding="10" Margin="0" HorizontalAlignment="Stretch">
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        <Border x:Name="Bd" Background="Transparent" Padding="16,0" HorizontalAlignment="Stretch">
+                            <ContentPresenter ContentSource="Header"
+                                              HorizontalAlignment="Center"
+                                              VerticalAlignment="Center" />
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
@@ -51,6 +59,11 @@
                             <Trigger Property="IsSelected" Value="True">
                                 <Setter TargetName="Bd" Property="Background" Value="{StaticResource AccentBrush}" />
                                 <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+                                <Setter TargetName="Bd" Property="Effect">
+                                    <Setter.Value>
+                                        <DropShadowEffect Color="#000000" BlurRadius="4" ShadowDepth="0" Opacity="0.3" />
+                                    </Setter.Value>
+                                </Setter>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -72,68 +85,77 @@
     </Window.Triggers>
     <TabControl>
         <TabItem Header="Главная">
-            <Grid Margin="24,24,32,24">
-                <TextBlock Text="Добро пожаловать" FontSize="20" FontWeight="Bold" />
+            <Grid>
+                <TextBlock Text="Добро пожаловать" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" />
             </Grid>
         </TabItem>
         <TabItem Header="Дебафы">
             <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <Grid Margin="0" HorizontalAlignment="Stretch">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="2*" />
-                    <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <Border Style="{StaticResource Card}" Margin="24,24,8,24">
-                        <StackPanel>
-                            <TextBlock Text="Категории дебаффов" FontWeight="Bold" FontSize="16" />
-                            <CheckBox Content="Легкий" IsChecked="{Binding EasyEnabled}" />
-                            <CheckBox Content="Средний" IsChecked="{Binding MediumEnabled}" />
-                            <CheckBox Content="Сложный" IsChecked="{Binding HardEnabled}" />
-                            <ListBox ItemsSource="{Binding AllDebuffs}" Margin="0,10,0,0" IsEnabled="{Binding AnyCategoryEnabled}" Width="300" ScrollViewer.VerticalScrollBarVisibility="Auto">
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <Grid Margin="0,5">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="Auto" />
-                                            </Grid.ColumnDefinitions>
-                                            <TextBlock Text="{Binding Name}" Grid.Column="0" Margin="0,0,10,0" />
-                                            <Button Content="Запустить"
-                                                    Command="{Binding DataContext.RunDebuffCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
-                                                    CommandParameter="{Binding}" Grid.Column="1" />
-                                        </Grid>
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                            </ListBox>
-                            <TextBlock Text="Путь к cfg" Margin="0,10,0,0" />
-                            <StackPanel Orientation="Horizontal">
-                                <TextBox Width="200" Text="{Binding ConfigPath}" />
-                                <Button Content="..." Command="{Binding BrowseConfigCommand}" Margin="5,0,0,0" />
+                <StackPanel>
+                    <TextBlock Text="Дебафы" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" />
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Border Style="{StaticResource Card}" Margin="0,0,8,0">
+                            <StackPanel>
+                                <TextBlock Text="Категории дебаффов" FontWeight="Bold" FontSize="16" />
+                                <CheckBox Content="Легкий" IsChecked="{Binding EasyEnabled}" />
+                                <CheckBox Content="Средний" IsChecked="{Binding MediumEnabled}" />
+                                <CheckBox Content="Сложный" IsChecked="{Binding HardEnabled}" />
+                                <ListBox ItemsSource="{Binding AllDebuffs}" Margin="0,10,0,0" IsEnabled="{Binding AnyCategoryEnabled}" Width="300" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <Grid Margin="0,5">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Text="{Binding Name}" Grid.Column="0" Margin="0,0,10,0" />
+                                                <Button Content="Запустить"
+                                                        Command="{Binding DataContext.RunDebuffCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                                        CommandParameter="{Binding}" Grid.Column="1" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                                <TextBlock Text="Путь к cfg" Margin="0,10,0,0" />
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBox Width="200" Text="{Binding ConfigPath}" />
+                                    <Button Content="..." Command="{Binding BrowseConfigCommand}" Margin="5,0,0,0" />
+                                </StackPanel>
+                                <Button Content="Инициализировать конфиг" Command="{Binding InitConfigCommand}" Margin="0,5,0,0" />
+                                <Button Content="Инициализировать команды" Command="{Binding InitCommandsCommand}" Margin="0,5,0,0" IsEnabled="{Binding CanInitCommands}" />
                             </StackPanel>
-                            <Button Content="Инициализировать конфиг" Command="{Binding InitConfigCommand}" Margin="0,5,0,0" />
-                            <Button Content="Инициализировать команды" Command="{Binding InitCommandsCommand}" Margin="0,5,0,0" IsEnabled="{Binding CanInitCommands}" />
-                        </StackPanel>
-                    </Border>
-                    <Border Grid.Column="1" Style="{StaticResource Card}" Margin="8,24,32,24">
-                        <StackPanel>
-                            <TextBlock Text="Лог событий" FontWeight="Bold" FontSize="16" />
-                            <ListBox ItemsSource="{Binding EventLog}" Height="200" />
-                            <TextBlock Text="{Binding GsiStatus}" Margin="0,10,0,0" />
-                            <Button Content="Запустить Dota 2" Command="{Binding StartDotaCommand}" Visibility="{Binding IsDotaRunning,Converter={StaticResource BoolInvertVisibilityConverter}}" Margin="0,5,0,0" />
-                            <CheckBox Content="Проверить отслеживание героя" IsChecked="{Binding IsHeroTrackingEnabled}" Margin="0,5,0,0" />
-                        </StackPanel>
-                    </Border>
-                </Grid>
+                        </Border>
+                        <Border Grid.Column="1" Style="{StaticResource Card}" Margin="8,0,0,0">
+                            <StackPanel>
+                                <TextBlock Text="Лог событий" FontWeight="Bold" FontSize="16" />
+                                <ListBox ItemsSource="{Binding EventLog}" Height="200" />
+                                <TextBlock Text="{Binding GsiStatus}" Margin="0,10,0,0" />
+                                <Button Content="Запустить Dota 2" Command="{Binding StartDotaCommand}" Visibility="{Binding IsDotaRunning,Converter={StaticResource BoolInvertVisibilityConverter}}" Margin="0,5,0,0" />
+                                <CheckBox Content="Проверить отслеживание героя" IsChecked="{Binding IsHeroTrackingEnabled}" Margin="0,5,0,0" />
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </StackPanel>
             </ScrollViewer>
         </TabItem>
         <TabItem Header="Настройки">
-            <views:SettingsView />
+            <StackPanel>
+                <TextBlock Text="Настройки" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" />
+                <views:SettingsView />
+            </StackPanel>
         </TabItem>
         <TabItem Header="Дебаг">
             <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <Grid Margin="24" HorizontalAlignment="Center">
-                    <ListBox ItemsSource="{Binding DebugLog}" Width="400" />
-                </Grid>
+                <StackPanel>
+                    <TextBlock Text="Дебаг" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" />
+                    <Border Style="{StaticResource Card}">
+                        <ListBox ItemsSource="{Binding DebugLog}" Width="400" />
+                    </Border>
+                </StackPanel>
             </ScrollViewer>
         </TabItem>
     </TabControl>


### PR DESCRIPTION
## Summary
- reinstate two-column layout with centered navigation
- apply consistent tab item style and accents
- add headers and card containers for main content
- ensure left panel hosts only four static tabs and keeps 48px spacing

## Testing
- `dotnet build /p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f728d8948322952dead15d9c239e