### PR TITLE
Extract tab content into views

### DIFF
--- a/GoodWin.Gui/MainWindow.xaml
+++ b/GoodWin.Gui/MainWindow.xaml
@@ -45,7 +45,7 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="TabItem">
                         <Border x:Name="Bd" Background="Transparent" Padding="16" HorizontalAlignment="Stretch">
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            <ContentPresenter ContentSource="Header" HorizontalAlignment="Center" VerticalAlignment="Center" />
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
@@ -80,83 +80,16 @@
     </Window.Triggers>
     <TabControl>
         <TabItem Header="Главная">
-            <StackPanel>
-                <TextBlock Text="Главная" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" Foreground="{StaticResource TextBrush}" />
-                <Border Style="{StaticResource Card}">
-                    <TextBlock Text="Добро пожаловать в GoodWinFun" />
-                </Border>
-            </StackPanel>
+            <views:HomeView />
         </TabItem>
         <TabItem Header="Дебафы">
-            <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <StackPanel>
-                    <TextBlock Text="Дебафы" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" Foreground="{StaticResource TextBrush}" />
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="2*" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <Border Style="{StaticResource Card}" Margin="0,0,8,0">
-                    <StackPanel>
-                        <TextBlock Text="Категории дебаффов" FontWeight="Bold" FontSize="16" Foreground="{StaticResource TextBrush}" />
-                        <CheckBox Content="Легкий" IsChecked="{Binding EasyEnabled}" Style="{StaticResource ToggleSwitch}" />
-                        <CheckBox Content="Средний" IsChecked="{Binding MediumEnabled}" Style="{StaticResource ToggleSwitch}" />
-                        <CheckBox Content="Сложный" IsChecked="{Binding HardEnabled}" Style="{StaticResource ToggleSwitch}" />
-                                <ListBox ItemsSource="{Binding AllDebuffs}" Margin="0,10,0,0" IsEnabled="{Binding AnyCategoryEnabled}" Width="300" ScrollViewer.VerticalScrollBarVisibility="Auto">
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <Grid Margin="0,5">
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*" />
-                                                    <ColumnDefinition Width="Auto" />
-                                                </Grid.ColumnDefinitions>
-                                                <TextBlock Text="{Binding Name}" Grid.Column="0" Margin="0,0,10,0" />
-                                                <Button Content="Запустить"
-                                                        Command="{Binding DataContext.RunDebuffCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
-                                                        CommandParameter="{Binding}" Grid.Column="1" />
-                                            </Grid>
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-                                </ListBox>
-                                <TextBlock Text="Путь к cfg" Margin="0,10,0,0" />
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBox Width="200" Text="{Binding ConfigPath}" />
-                                    <Button Content="..." Command="{Binding BrowseConfigCommand}" Margin="5,0,0,0" />
-                                </StackPanel>
-                                <Button Content="Инициализировать конфиг" Command="{Binding InitConfigCommand}" Margin="0,5,0,0" />
-                                <Button Content="Инициализировать команды" Command="{Binding InitCommandsCommand}" Margin="0,5,0,0" IsEnabled="{Binding CanInitCommands}" />
-                            </StackPanel>
-                        </Border>
-                        <Border Grid.Column="1" Style="{StaticResource Card}" Margin="8,0,0,0">
-                            <StackPanel>
-                                  <TextBlock Text="Лог событий" FontWeight="Bold" FontSize="16" Foreground="{StaticResource TextBrush}" />
-                                <ListBox ItemsSource="{Binding EventLog}" Height="200" />
-                                <TextBlock Text="{Binding GsiStatus}" Margin="0,10,0,0" />
-                                <Button Content="Запустить Dota 2" Command="{Binding StartDotaCommand}" Visibility="{Binding IsDotaRunning,Converter={StaticResource BoolInvertVisibilityConverter}}" Margin="0,5,0,0" />
-                                  <CheckBox Content="Проверить отслеживание героя" IsChecked="{Binding IsHeroTrackingEnabled}" Margin="0,5,0,0" Style="{StaticResource ToggleSwitch}" />
-                            </StackPanel>
-                        </Border>
-                    </Grid>
-                </StackPanel>
-            </ScrollViewer>
+            <views:DebuffsView />
         </TabItem>
         <TabItem Header="Настройки">
-            <StackPanel>
-                <TextBlock Text="Настройки" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" Foreground="{StaticResource TextBrush}" />
-                <Border Style="{StaticResource Card}">
-                    <views:SettingsView />
-                </Border>
-            </StackPanel>
+            <views:SettingsView />
         </TabItem>
         <TabItem Header="Дебаг">
-            <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <StackPanel>
-                    <TextBlock Text="Дебаг" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" Foreground="{StaticResource TextBrush}" />
-                    <Border Style="{StaticResource Card}">
-                        <ListBox ItemsSource="{Binding DebugLog}" Width="400" />
-                    </Border>
-                </StackPanel>
-            </ScrollViewer>
+            <views:DebugView />
         </TabItem>
     </TabControl>
 </Window>

--- a/GoodWin.Gui/Views/DebuffsView.xaml
+++ b/GoodWin.Gui/Views/DebuffsView.xaml
@@ -1,0 +1,56 @@
+<UserControl x:Class="GoodWin.Gui.Views.DebuffsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <TextBlock Text="Дебафы" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" Foreground="{StaticResource TextBrush}" />
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Border Style="{StaticResource Card}" Margin="0,0,8,0">
+                    <StackPanel>
+                        <TextBlock Text="Категории дебаффов" FontWeight="Bold" FontSize="16" Foreground="{StaticResource TextBrush}" />
+                        <CheckBox Content="Легкий" IsChecked="{Binding EasyEnabled}" Style="{StaticResource ToggleSwitch}" />
+                        <CheckBox Content="Средний" IsChecked="{Binding MediumEnabled}" Style="{StaticResource ToggleSwitch}" />
+                        <CheckBox Content="Сложный" IsChecked="{Binding HardEnabled}" Style="{StaticResource ToggleSwitch}" />
+                        <ListBox ItemsSource="{Binding AllDebuffs}" Margin="0,10,0,0" IsEnabled="{Binding AnyCategoryEnabled}" Width="300" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Margin="0,5">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="{Binding Name}" Grid.Column="0" Margin="0,0,10,0" />
+                                        <Button Content="Запустить"
+                                                Command="{Binding DataContext.RunDebuffCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                                CommandParameter="{Binding}" Grid.Column="1" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                        <TextBlock Text="Путь к cfg" Margin="0,10,0,0" />
+                        <StackPanel Orientation="Horizontal">
+                            <TextBox Width="200" Text="{Binding ConfigPath}" />
+                            <Button Content="..." Command="{Binding BrowseConfigCommand}" Margin="5,0,0,0" />
+                        </StackPanel>
+                        <Button Content="Инициализировать конфиг" Command="{Binding InitConfigCommand}" Margin="0,5,0,0" />
+                        <Button Content="Инициализировать команды" Command="{Binding InitCommandsCommand}" Margin="0,5,0,0" IsEnabled="{Binding CanInitCommands}" />
+                    </StackPanel>
+                </Border>
+                <Border Grid.Column="1" Style="{StaticResource Card}" Margin="8,0,0,0">
+                    <StackPanel>
+                        <TextBlock Text="Лог событий" FontWeight="Bold" FontSize="16" Foreground="{StaticResource TextBrush}" />
+                        <ListBox ItemsSource="{Binding EventLog}" Height="200" />
+                        <TextBlock Text="{Binding GsiStatus}" Margin="0,10,0,0" />
+                        <Button Content="Запустить Dota 2" Command="{Binding StartDotaCommand}" Visibility="{Binding IsDotaRunning,Converter={StaticResource BoolInvertVisibilityConverter}}" Margin="0,5,0,0" />
+                        <CheckBox Content="Проверить отслеживание героя" IsChecked="{Binding IsHeroTrackingEnabled}" Margin="0,5,0,0" Style="{StaticResource ToggleSwitch}" />
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>
+

--- a/GoodWin.Gui/Views/DebuffsView.xaml.cs
+++ b/GoodWin.Gui/Views/DebuffsView.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+
+namespace GoodWin.Gui.Views
+{
+    public partial class DebuffsView : UserControl
+    {
+        public DebuffsView()
+        {
+            InitializeComponent();
+        }
+    }
+}
+

--- a/GoodWin.Gui/Views/DebugView.xaml
+++ b/GoodWin.Gui/Views/DebugView.xaml
@@ -1,0 +1,13 @@
+<UserControl x:Class="GoodWin.Gui.Views.DebugView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <TextBlock Text="Дебаг" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" Foreground="{StaticResource TextBrush}" />
+            <Border Style="{StaticResource Card}">
+                <ListBox ItemsSource="{Binding DebugLog}" Width="400" />
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>
+

--- a/GoodWin.Gui/Views/DebugView.xaml.cs
+++ b/GoodWin.Gui/Views/DebugView.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+
+namespace GoodWin.Gui.Views
+{
+    public partial class DebugView : UserControl
+    {
+        public DebugView()
+        {
+            InitializeComponent();
+        }
+    }
+}
+

--- a/GoodWin.Gui/Views/HomeView.xaml
+++ b/GoodWin.Gui/Views/HomeView.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="GoodWin.Gui.Views.HomeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel>
+        <TextBlock Text="Главная" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" Foreground="{StaticResource TextBrush}" />
+        <Border Style="{StaticResource Card}">
+            <TextBlock Text="Добро пожаловать в GoodWinFun" />
+        </Border>
+    </StackPanel>
+</UserControl>
+

--- a/GoodWin.Gui/Views/HomeView.xaml.cs
+++ b/GoodWin.Gui/Views/HomeView.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+
+namespace GoodWin.Gui.Views
+{
+    public partial class HomeView : UserControl
+    {
+        public HomeView()
+        {
+            InitializeComponent();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add HomeView, DebuffsView and DebugView user controls
- simplify MainWindow tab items to use dedicated views
- show TabItem header using `ContentSource`

## Testing
- `dotnet build GoodWinDebuff.sln` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*


------
https://chatgpt.com/codex/tasks/task_e_689311ac03248322a4525c263ea067c3