### PR TITLE
Fix converter resource for debuffs view

### DIFF
--- a/GoodWin.Gui/MainWindow.xaml
+++ b/GoodWin.Gui/MainWindow.xaml
@@ -5,12 +5,9 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:GoodWin.Gui.ViewModels"
         xmlns:views="clr-namespace:GoodWin.Gui.Views"
-        xmlns:conv="clr-namespace:GoodWin.Gui.Converters"
         mc:Ignorable="d"
         Title="GoodWin Debuff" Height="600" Width="800" WindowStartupLocation="CenterScreen">
     <Window.Resources>
-        <conv:BoolInvertVisibilityConverter x:Key="BoolInvertVisibilityConverter" />
-
         <!-- Navigation TabControl style -->
         <Style TargetType="TabControl">
             <Setter Property="Template">

--- a/GoodWin.Gui/Views/DebuffsView.xaml
+++ b/GoodWin.Gui/Views/DebuffsView.xaml
@@ -1,6 +1,10 @@
 <UserControl x:Class="GoodWin.Gui.Views.DebuffsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:conv="clr-namespace:GoodWin.Gui.Converters">
+    <UserControl.Resources>
+        <conv:BoolInvertVisibilityConverter x:Key="BoolInvertVisibilityConverter" />
+    </UserControl.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
             <TextBlock Text="Дебафы" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" Foreground="{StaticResource TextBrush}" />


### PR DESCRIPTION
## Summary
- ensure BoolInvertVisibilityConverter is available in DebuffsView
- clean up MainWindow resources

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop"))*

------
https://chatgpt.com/codex/tasks/task_e_6893143857bc832298b859b2ec6a6e20