### PR TITLE
Fix TabControl content binding

### DIFF
--- a/GoodWin.Gui/MainWindow.xaml
+++ b/GoodWin.Gui/MainWindow.xaml
@@ -22,7 +22,8 @@
                                 <TabPanel x:Name="HeaderPanel" IsItemsHost="True" Background="{StaticResource NavBackground}" />
                             </StackPanel>
                             <Border Grid.Column="1" Background="{StaticResource AppBackground}" Padding="24,16,32,16">
-                                <ContentPresenter x:Name="PART_SelectedContentHost" />
+                                <ContentPresenter x:Name="PART_SelectedContentHost"
+                                                  ContentSource="SelectedContent" />
                             </Border>
                         </Grid>
                     </ControlTemplate>


### PR DESCRIPTION
## Summary
- bind TabControl content presenter to the selected tab content

## Testing
- `dotnet build GoodWinDebuff.sln` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_6893174bbae88322a12f647d5cfc5cb7