### PR TITLE
Prevent inverted mouse at top/bottom edges

### DIFF
--- a/GoodWin.Utils/InputHookHost.cs
+++ b/GoodWin.Utils/InputHookHost.cs
@@ -121,6 +121,12 @@ namespace GoodWin.Utils
                         }
                         if (_mouseLag > 0)
                             Thread.Sleep(200);
+                        int screenHeight = Screen.PrimaryScreen.Bounds.Height;
+                        if (data.pt.y <= 0 || data.pt.y >= screenHeight - 1)
+                        {
+                            _lastMousePt = data.pt;
+                            return CallNextHookEx(_mouseHook, nCode, wParam, lParam);
+                        }
                         if (_invertY > 0)
                         {
                             int dx = data.pt.x - _lastMousePt.x;


### PR DESCRIPTION
## Summary
- Check screen boundaries before inverting mouse movement
- Skip inversion when cursor hits screen top or bottom

## Testing
- `dotnet test` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68936b2c9c28832294789c11cc2a3277