### PR TITLE
Improve debuff management and tracking

### DIFF
--- a/GoodWin.Debuffs.Medium/ToxicChatDebuff.cs
+++ b/GoodWin.Debuffs.Medium/ToxicChatDebuff.cs
@@ -28,12 +28,13 @@ namespace GoodWin.Debuffs.Medium
         };
 
         private CancellationTokenSource? _cts;
+        private Task? _task;
 
         public override void Apply()
         {
             _cts = new CancellationTokenSource();
             var token = _cts.Token;
-            _ = Task.Run(async () =>
+            _task = Task.Run(async () =>
             {
                 var rnd = new Random();
                 var end = DateTime.UtcNow.AddSeconds(60);
@@ -63,7 +64,14 @@ namespace GoodWin.Debuffs.Medium
 
         public override void Remove()
         {
-            _cts?.Cancel();
+            if (_cts != null)
+            {
+                _cts.Cancel();
+                try { _task?.Wait(); } catch (AggregateException ae) { ae.Handle(e => e is TaskCanceledException); }
+                _cts.Dispose();
+                _cts = null;
+                _task = null;
+            }
             Console.WriteLine("[ToxicChat] Дебафф завершён");
         }
     }

--- a/GoodWin.Tracker/GoodWin.Tracker.csproj
+++ b/GoodWin.Tracker/GoodWin.Tracker.csproj
@@ -7,6 +7,7 @@
         <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GoodWin.Tracker/ScreenCaptureService.cs
+++ b/GoodWin.Tracker/ScreenCaptureService.cs
@@ -41,10 +41,10 @@ namespace GoodWin.Tracker
             try
             {
                 var bounds = Screen.PrimaryScreen.Bounds;
-                var bmp = new Bitmap(bounds.Width, bounds.Height);
+                using var bmp = new Bitmap(bounds.Width, bounds.Height);
                 using var g = Graphics.FromImage(bmp);
                 g.CopyFromScreen(bounds.Location, Point.Empty, bounds.Size);
-                FrameCaptured?.Invoke(bmp);
+                FrameCaptured?.Invoke((Bitmap)bmp.Clone());
             }
             catch
             {

--- a/GoodWin.Utils/OverlayWindow.cs
+++ b/GoodWin.Utils/OverlayWindow.cs
@@ -37,8 +37,8 @@ namespace GoodWin.Utils
                         _instance.SourceInitialized += (s, e) =>
                         {
                             var hwnd = new WindowInteropHelper(_instance).Handle;
-                            var exStyle = NativeMethods.GetWindowLong(hwnd, NativeMethods.GWL_EXSTYLE);
-                            NativeMethods.SetWindowLong(
+                            var exStyle = NativeMethods.GetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE);
+                            NativeMethods.SetWindowLongPtr(
                                 hwnd,
                                 NativeMethods.GWL_EXSTYLE,
                                 new IntPtr(exStyle.ToInt64() |
@@ -125,11 +125,23 @@ namespace GoodWin.Utils
             public const int WS_EX_TRANSPARENT = 0x20;
             public const int WS_EX_LAYERED = 0x80000;
 
-            [DllImport("user32.dll", SetLastError = true)]
-            public static extern IntPtr GetWindowLong(IntPtr hWnd, int nIndex);
+            [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr", SetLastError = true)]
+            private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
 
-            [DllImport("user32.dll", SetLastError = true)]
-            public static extern IntPtr SetWindowLong(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+            [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr", SetLastError = true)]
+            private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+            [DllImport("user32.dll", EntryPoint = "GetWindowLong", SetLastError = true)]
+            private static extern IntPtr GetWindowLong32(IntPtr hWnd, int nIndex);
+
+            [DllImport("user32.dll", EntryPoint = "SetWindowLong", SetLastError = true)]
+            private static extern IntPtr SetWindowLong32(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+            public static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)
+                => IntPtr.Size == 8 ? GetWindowLongPtr64(hWnd, nIndex) : GetWindowLong32(hWnd, nIndex);
+
+            public static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+                => IntPtr.Size == 8 ? SetWindowLongPtr64(hWnd, nIndex, dwNewLong) : SetWindowLong32(hWnd, nIndex, dwNewLong);
         }
     }
 }


### PR DESCRIPTION
## Summary
- support constructor parameters when loading debuffs via user settings
- ensure manual debuffs end after duration and expose async command APIs
- optimize screen capture and hero detection, and clean up debuff background tasks

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_e_68936c1b9f74832297e7b7705f240b49