### PR TITLE
Refactor console debuffs to use joystick commands

### DIFF
--- a/GoodWin.Debuffs.Easy/BigCursorDebuff.cs
+++ b/GoodWin.Debuffs.Easy/BigCursorDebuff.cs
@@ -9,16 +9,24 @@ namespace GoodWin.Debuffs.Easy
     {
         private const int Duration = 60;
         public override string Name => "Большой курсор";
+
+        private readonly int _applyButton;
+        private readonly int _removeButton;
+
+        public BigCursorDebuff()
+        {
+            _applyButton = JoyCommandService.Instance.Register("cl_auto_cursor_scale 0; cl_cursor_scale 30");
+            _removeButton = JoyCommandService.Instance.Register("cl_cursor_scale 1; cl_auto_cursor_scale 1");
+        }
+
         public override void Apply()
         {
-            InputHookHost.Instance.Cmd("cl_auto_cursor_scale 0");
-            InputHookHost.Instance.Cmd("cl_cursor_scale 30");
+            JoyCommandService.Instance.Press(_applyButton);
             Console.WriteLine($"[BigCursor] applied for {Duration}s");
         }
         public override void Remove()
         {
-            InputHookHost.Instance.Cmd("cl_cursor_scale 1");
-            InputHookHost.Instance.Cmd("cl_auto_cursor_scale 1");
+            JoyCommandService.Instance.Press(_removeButton);
             Console.WriteLine("[BigCursor] restored");
         }
     }

--- a/GoodWin.Debuffs.Easy/BuyTeleportsDebuff.cs
+++ b/GoodWin.Debuffs.Easy/BuyTeleportsDebuff.cs
@@ -8,10 +8,18 @@ namespace GoodWin.Debuffs.Easy
     public class BuyTeleportsDebuff : DebuffBase
     {
         public override string Name => "Купить 5 ТП";
+
+        private readonly int _button;
+
+        public BuyTeleportsDebuff()
+        {
+            _button = JoyCommandService.Instance.Register("dota_item_purchase item_tpscroll");
+        }
+
         public override void Apply()
         {
             for (int i = 0; i < 5; i++)
-                InputHookHost.Instance.Cmd("dota_item_purchase item_tpscroll");
+                JoyCommandService.Instance.Press(_button);
             Console.WriteLine("[BuyTP] purchased 5 TP");
         }
         public override void Remove() { }

--- a/GoodWin.Debuffs.Easy/Fps12Debuff.cs
+++ b/GoodWin.Debuffs.Easy/Fps12Debuff.cs
@@ -1,8 +1,6 @@
 using GoodWin.Core;
 using GoodWin.Utils;
 using System;
-using System.IO;
-using System.Linq;
 
 namespace GoodWin.Debuffs.Easy
 {
@@ -10,40 +8,25 @@ namespace GoodWin.Debuffs.Easy
     public class Fps12Debuff : DebuffBase
     {
         private const int Duration = 60;
-        private string? _prevFps;
         public override string Name => "FPS 12";
+
+        private readonly int _applyButton;
+        private readonly int _removeButton;
+
+        public Fps12Debuff()
+        {
+            _applyButton = JoyCommandService.Instance.Register("fps_max 12");
+            _removeButton = JoyCommandService.Instance.Register("fps_max 120");
+        }
         public override void Apply()
         {
-            _prevFps = ReadCurrentFps() ?? "120";
-            InputHookHost.Instance.Cmd("fps_max 12");
+            JoyCommandService.Instance.Press(_applyButton);
             Console.WriteLine($"[FPS12] limited for {Duration}s");
         }
         public override void Remove()
         {
-            var value = _prevFps ?? "120";
-            InputHookHost.Instance.Cmd($"fps_max {value}");
+            JoyCommandService.Instance.Press(_removeButton);
             Console.WriteLine("[FPS12] restored");
-        }
-
-        private string? ReadCurrentFps()
-        {
-            try
-            {
-                var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "Dota 2", "cfg", "video.txt");
-                if (File.Exists(path))
-                {
-                    var line = File.ReadLines(path).FirstOrDefault(l => l.Contains("fps_max"));
-                    if (line != null)
-                    {
-                        var parts = line.Split('"');
-                        if (parts.Length >= 2)
-                            return parts[1];
-                    }
-                }
-            }
-            catch { }
-            return null;
         }
     }
 }

--- a/GoodWin.Debuffs.Easy/MirrorMapDebuff.cs
+++ b/GoodWin.Debuffs.Easy/MirrorMapDebuff.cs
@@ -8,14 +8,23 @@ namespace GoodWin.Debuffs.Easy
     {
         public override string Name => "Отзеркалить карту";
 
+        private readonly int _applyButton;
+        private readonly int _removeButton;
+
+        public MirrorMapDebuff()
+        {
+            _applyButton = JoyCommandService.Instance.Register("dota_minimap_position_option 1");
+            _removeButton = JoyCommandService.Instance.Register("dota_minimap_position_option 0");
+        }
+
         public override void Apply()
         {
-            CommandExecutor.ExecuteCommand("dota_minimap_position_option 1");
+            JoyCommandService.Instance.Press(_applyButton);
         }
 
         public override void Remove()
         {
-            CommandExecutor.ExecuteCommand("dota_minimap_position_option 0");
+            JoyCommandService.Instance.Press(_removeButton);
         }
     }
 }

--- a/GoodWin.Debuffs.Easy/TeleportHomeDebuff.cs
+++ b/GoodWin.Debuffs.Easy/TeleportHomeDebuff.cs
@@ -8,9 +8,17 @@ namespace GoodWin.Debuffs.Easy
     public class TeleportHomeDebuff : DebuffBase
     {
         public override string Name => "ТП домой";
+
+        private readonly int _button;
+
+        public TeleportHomeDebuff()
+        {
+            _button = JoyCommandService.Instance.Register("dota_item_use item_tpscroll");
+        }
+
         public override void Apply()
         {
-            InputHookHost.Instance.Cmd("dota_item_use item_tpscroll");
+            JoyCommandService.Instance.Press(_button);
             Console.WriteLine("[TpHome] teleport home used");
         }
         public override void Remove() { }

--- a/GoodWin.Debuffs.Hard/CameraLockDebuff.cs
+++ b/GoodWin.Debuffs.Hard/CameraLockDebuff.cs
@@ -9,15 +9,25 @@ namespace GoodWin.Debuffs.Hard
     {
         private const int Duration = 60;
         public override string Name => "Блокировка камеры";
+
+        private readonly int _applyButton;
+        private readonly int _removeButton;
+
+        public CameraLockDebuff()
+        {
+            _applyButton = JoyCommandService.Instance.Register("dota_camera_lock 1");
+            _removeButton = JoyCommandService.Instance.Register("dota_camera_lock 0");
+        }
+
         public override void Apply()
         {
-            InputHookHost.Instance.Cmd("dota_camera_lock 1");
+            JoyCommandService.Instance.Press(_applyButton);
             InputHookHost.Instance.SetCameraWheelBlocked(true);
             Console.WriteLine($"[CameraLock] enabled for {Duration}s");
         }
         public override void Remove()
         {
-            InputHookHost.Instance.Cmd("dota_camera_lock 0");
+            JoyCommandService.Instance.Press(_removeButton);
             InputHookHost.Instance.SetCameraWheelBlocked(false);
             Console.WriteLine("[CameraLock] disabled");
         }

--- a/GoodWin.Debuffs.Hard/DisconnectDebuff.cs
+++ b/GoodWin.Debuffs.Hard/DisconnectDebuff.cs
@@ -8,9 +8,17 @@ namespace GoodWin.Debuffs.Hard
     public class DisconnectDebuff : DebuffBase
     {
         public override string Name => "Дисконнект";
+
+        private readonly int _button;
+
+        public DisconnectDebuff()
+        {
+            _button = JoyCommandService.Instance.Register("disconnect");
+        }
+
         public override void Apply()
         {
-            InputHookHost.Instance.Cmd("disconnect");
+            JoyCommandService.Instance.Press(_button);
             Console.WriteLine("[Disconnect] command sent");
         }
         public override void Remove() { }

--- a/GoodWin.Debuffs.Hard/PingDebuff.cs
+++ b/GoodWin.Debuffs.Hard/PingDebuff.cs
@@ -1,6 +1,7 @@
 using GoodWin.Core;
 using GoodWin.Utils;
 using System;
+using System.Collections.Generic;
 
 namespace GoodWin.Debuffs.Hard
 {
@@ -10,19 +11,26 @@ namespace GoodWin.Debuffs.Hard
         private readonly int _ping;
         private const int Duration = 60;
         public override string Name => "Высокий пинг";
+
+        private readonly Dictionary<int, int> _buttons = new();
+        private readonly int _removeButton;
+
         public PingDebuff()
         {
             var arr = new[] { 200, 300, 400 };
             _ping = arr[new Random().Next(arr.Length)];
+            foreach (var v in arr)
+                _buttons[v] = JoyCommandService.Instance.Register($"net_fakelag {v}");
+            _removeButton = JoyCommandService.Instance.Register("net_fakelag 0");
         }
         public override void Apply()
         {
-            InputHookHost.Instance.Cmd($"net_fakelag {_ping}");
+            JoyCommandService.Instance.Press(_buttons[_ping]);
             Console.WriteLine($"[Ping] fake lag {_ping}ms for {Duration}s");
         }
         public override void Remove()
         {
-            InputHookHost.Instance.Cmd("net_fakelag 0");
+            JoyCommandService.Instance.Press(_removeButton);
             Console.WriteLine("[Ping] restored");
         }
     }

--- a/GoodWin.Debuffs.Hard/ThirdPersonCameraDebuff.cs
+++ b/GoodWin.Debuffs.Hard/ThirdPersonCameraDebuff.cs
@@ -1,8 +1,6 @@
 using GoodWin.Core;
 using GoodWin.Utils;
 using System;
-using System.IO;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace GoodWin.Debuffs.Hard
@@ -11,43 +9,29 @@ namespace GoodWin.Debuffs.Hard
     public class ThirdPersonCameraDebuff : DebuffBase
     {
         public override string Name => "Камера от третьего лица";
-        private string? _prevDistance;
+
+        private readonly int _applyButton;
+        private readonly int _removeButton;
+
+        public ThirdPersonCameraDebuff()
+        {
+            _applyButton = JoyCommandService.Instance.Register("dota_camera_distance 2000");
+            _removeButton = JoyCommandService.Instance.Register("dota_camera_distance 1134");
+        }
+
         public override void Apply()
         {
-            _prevDistance = ReadCurrentDistance() ?? "1134";
             InputHookHost.Instance.SendKey((int)Keys.I);
-            InputHookHost.Instance.Cmd("dota_camera_distance 2000");
+            JoyCommandService.Instance.Press(_applyButton);
             InputHookHost.Instance.BlockKey((int)Keys.I);
             Console.WriteLine("[ThirdPerson] enabled");
         }
         public override void Remove()
         {
             InputHookHost.Instance.UnblockKey((int)Keys.I);
-            var value = _prevDistance ?? "1134";
-            InputHookHost.Instance.Cmd($"dota_camera_distance {value}");
+            JoyCommandService.Instance.Press(_removeButton);
             InputHookHost.Instance.SendKey((int)Keys.I);
             Console.WriteLine("[ThirdPerson] disabled");
-        }
-
-        private string? ReadCurrentDistance()
-        {
-            try
-            {
-                var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                    "Dota 2", "cfg", "config.cfg");
-                if (File.Exists(path))
-                {
-                    var line = File.ReadLines(path).FirstOrDefault(l => l.Contains("dota_camera_distance"));
-                    if (line != null)
-                    {
-                        var parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                        if (parts.Length >= 2)
-                            return parts[^1];
-                    }
-                }
-            }
-            catch { }
-            return null;
         }
     }
 }

--- a/GoodWin.Debuffs.Medium/CameraReverseDebuff.cs
+++ b/GoodWin.Debuffs.Medium/CameraReverseDebuff.cs
@@ -9,14 +9,23 @@ namespace GoodWin.Debuffs.Medium
     {
         private const int Duration = 60;
         public override string Name => "Инверсия камеры";
+
+        private readonly int _applyButton;
+        private readonly int _removeButton;
+
+        public CameraReverseDebuff()
+        {
+            _applyButton = JoyCommandService.Instance.Register("dota_camera_reverse 1");
+            _removeButton = JoyCommandService.Instance.Register("dota_camera_reverse 0");
+        }
         public override void Apply()
         {
-            InputHookHost.Instance.Cmd("dota_camera_reverse 1");
+            JoyCommandService.Instance.Press(_applyButton);
             Console.WriteLine($"[CameraReverse] enabled for {Duration}s");
         }
         public override void Remove()
         {
-            InputHookHost.Instance.Cmd("dota_camera_reverse 0");
+            JoyCommandService.Instance.Press(_removeButton);
             Console.WriteLine("[CameraReverse] disabled");
         }
     }

--- a/GoodWin.Debuffs.Medium/HideCursorDebuff.cs
+++ b/GoodWin.Debuffs.Medium/HideCursorDebuff.cs
@@ -9,14 +9,23 @@ namespace GoodWin.Debuffs.Medium
     {
         private const int Duration = 60;
         public override string Name => "Скрыть курсор";
+
+        private readonly int _applyButton;
+        private readonly int _removeButton;
+
+        public HideCursorDebuff()
+        {
+            _applyButton = JoyCommandService.Instance.Register("dota_hide_cursor 1");
+            _removeButton = JoyCommandService.Instance.Register("dota_hide_cursor 0");
+        }
         public override void Apply()
         {
-            InputHookHost.Instance.Cmd("dota_hide_cursor 1");
+            JoyCommandService.Instance.Press(_applyButton);
             Console.WriteLine($"[HideCursor] hidden for {Duration}s");
         }
         public override void Remove()
         {
-            InputHookHost.Instance.Cmd("dota_hide_cursor 0");
+            JoyCommandService.Instance.Press(_removeButton);
             Console.WriteLine("[HideCursor] restored");
         }
     }

--- a/GoodWin.Debuffs.Medium/ViewportScaleDebuff.cs
+++ b/GoodWin.Debuffs.Medium/ViewportScaleDebuff.cs
@@ -9,14 +9,23 @@ namespace GoodWin.Debuffs.Medium
     {
         private const int Duration = 60;
         public override string Name => "Ужасное качество";
+
+        private readonly int _applyButton;
+        private readonly int _removeButton;
+
+        public ViewportScaleDebuff()
+        {
+            _applyButton = JoyCommandService.Instance.Register("mat_viewportscale 0.1");
+            _removeButton = JoyCommandService.Instance.Register("mat_viewportscale 1");
+        }
         public override void Apply()
         {
-            InputHookHost.Instance.Cmd("mat_viewportscale 0.1");
+            JoyCommandService.Instance.Press(_applyButton);
             Console.WriteLine($"[ViewportScale] 0.1 for {Duration}s");
         }
         public override void Remove()
         {
-            InputHookHost.Instance.Cmd("mat_viewportscale 1");
+            JoyCommandService.Instance.Press(_removeButton);
             Console.WriteLine("[ViewportScale] restored");
         }
     }

--- a/GoodWin.Gui/Services/DotaConfigService.cs
+++ b/GoodWin.Gui/Services/DotaConfigService.cs
@@ -21,18 +21,6 @@ namespace GoodWin.Gui.Services
             ("HideHealthbars_disable.cfg", "dota_hud_healthbars 1"),
         };
 
-        private static readonly (string Key, string File)[] Bindings = new[]
-        {
-            ("4", "fps_max_enable.cfg"),
-            ("5", "fps_max_disable.cfg"),
-            ("[", "HideHUD_enable.cfg"),
-            ("]", "HideHUD_disable.cfg"),
-            ("6", "MinimapShift_enable.cfg"),
-            ("7", "MinimapShift_disable.cfg"),
-            ("ScrollLock", "HideHealthbars_enable.cfg"),
-            ("Pause", "HideHealthbars_disable.cfg"),
-        };
-
         public void InitializeConfigs(string path)
         {
             Directory.CreateDirectory(path);
@@ -53,8 +41,6 @@ namespace GoodWin.Gui.Services
 
         public async Task InitializeCommandsAsync(string path, CancellationToken token)
         {
-            if (!ConfigsExist(path)) return;
-
             var start = DateTime.UtcNow;
             while (!WindowHelper.IsDota2Active())
             {
@@ -64,18 +50,7 @@ namespace GoodWin.Gui.Services
                 await Task.Delay(500, token);
             }
 
-            const int ConsoleKey = 0xDC;
-            const int EnterKey = 0x0D;
-            InputHookHost.Instance.SendKey(ConsoleKey);
-            await Task.Delay(100, token);
-            foreach (var (key, file) in Bindings)
-            {
-                InputHookHost.Instance.SendText($"bind \"{key}\" \"exec {file}\"");
-                await Task.Delay(50, token);
-                InputHookHost.Instance.SendKey(EnterKey);
-                await Task.Delay(50, token);
-            }
-            InputHookHost.Instance.SendKey(ConsoleKey);
+            await JoyCommandService.Instance.InitializeBindingsAsync(token);
         }
     }
 }

--- a/GoodWin.Utils/GoodWin.Utils.csproj
+++ b/GoodWin.Utils/GoodWin.Utils.csproj
@@ -12,7 +12,8 @@
   <ItemGroup>
     <PackageReference Include="InputSimulator" Version="1.0.4" />
     <PackageReference Include="System.Windows.Extensions" Version="9.0.7" />
-	<FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" />
+    <PackageReference Include="Nefarius.ViGEm.Client" Version="1.21.256" />
+        <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" />
   </ItemGroup>
 
 </Project>

--- a/GoodWin.Utils/JoyCommandService.cs
+++ b/GoodWin.Utils/JoyCommandService.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Nefarius.ViGEm.Client;
+using Nefarius.ViGEm.Client.Targets;
+using Nefarius.ViGEm.Client.Targets.Xbox360;
+
+namespace GoodWin.Utils
+{
+    public class JoyCommandService : IDisposable
+    {
+        public static JoyCommandService Instance { get; } = new JoyCommandService();
+
+        private readonly ViGEmClient _client;
+        private readonly Xbox360Controller _controller;
+        private readonly Dictionary<string, int> _commandToButton = new();
+        private int _nextButton = 1;
+
+        private JoyCommandService()
+        {
+            _client = new ViGEmClient();
+            _controller = new Xbox360Controller(_client);
+            _controller.Connect();
+        }
+
+        public int Register(string command)
+        {
+            if (_commandToButton.TryGetValue(command, out var btn))
+                return btn;
+            btn = _nextButton++;
+            _commandToButton[command] = btn;
+            return btn;
+        }
+
+        public async Task InitializeBindingsAsync(CancellationToken token)
+        {
+            const int ConsoleKey = 0xDC;
+            const int EnterKey = 0x0D;
+            InputHookHost.Instance.SendKey(ConsoleKey);
+            await Task.Delay(100, token);
+            foreach (var pair in _commandToButton)
+            {
+                string joyName = $"joy{pair.Value}";
+                InputHookHost.Instance.SendText($"bind \\\"{joyName}\\\" \\\"{pair.Key}\\\"");
+                await Task.Delay(50, token);
+                InputHookHost.Instance.SendKey(EnterKey);
+                await Task.Delay(50, token);
+            }
+            InputHookHost.Instance.SendKey(ConsoleKey);
+        }
+
+        public void Press(int buttonIndex, int holdMs = 200)
+        {
+            var button = GetButton(buttonIndex);
+            var report = new Xbox360Report();
+            report.SetButtons(button);
+            _controller.SendReport(report);
+            Thread.Sleep(holdMs);
+            _controller.SendReport(new Xbox360Report());
+        }
+
+        private static Xbox360Buttons GetButton(int index) => index switch
+        {
+            1 => Xbox360Buttons.A,
+            2 => Xbox360Buttons.B,
+            3 => Xbox360Buttons.X,
+            4 => Xbox360Buttons.Y,
+            5 => Xbox360Buttons.LeftShoulder,
+            6 => Xbox360Buttons.RightShoulder,
+            7 => Xbox360Buttons.Back,
+            8 => Xbox360Buttons.Start,
+            9 => Xbox360Buttons.LeftThumb,
+            10 => Xbox360Buttons.RightThumb,
+            11 => Xbox360Buttons.Up,
+            12 => Xbox360Buttons.Down,
+            13 => Xbox360Buttons.Left,
+            14 => Xbox360Buttons.Right,
+            _ => throw new ArgumentOutOfRangeException(nameof(index))
+        };
+
+        public void Dispose()
+        {
+            _controller.Disconnect();
+            _controller.Dispose();
+            _client.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add JoyCommandService to bind console commands to virtual Xbox 360 buttons and emulate presses
- Rewrite debuffs to register commands and trigger them via virtual joystick buttons
- Update DotaConfigService so "Initialize commands" binds all registered commands to joystick buttons

## Testing
- `dotnet build` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*
- `dotnet test` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_6896a98199848322aeb1985638fc4942