### PR TITLE
Fix bind command quoting in JoyCommandService

### DIFF
--- a/GoodWin.Utils/JoyCommandService.cs
+++ b/GoodWin.Utils/JoyCommandService.cs
@@ -42,7 +42,7 @@ namespace GoodWin.Utils
             foreach (var pair in _commandToButton)
             {
                 string joyName = $"joy{pair.Value}";
-                InputHookHost.Instance.SendText($"bind \\\"{joyName}\\\" \\\"{pair.Key}\\\"");
+                InputHookHost.Instance.SendText($"bind \"{joyName}\" \"{pair.Key}\"");
                 await Task.Delay(50, token);
                 InputHookHost.Instance.SendKey(EnterKey);
                 await Task.Delay(50, token);


### PR DESCRIPTION
## Summary
- fix bind command to use direct quotes in JoyCommandService

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" )*

------
https://chatgpt.com/codex/tasks/task_e_6896b4c6ac1c8322906f2094ded0e4a7