### PR TITLE
Ensure debuff scheduler runs without ClockTime

### DIFF
--- a/GoodWin.Gui/ViewModels/MainViewModel.cs
+++ b/GoodWin.Gui/ViewModels/MainViewModel.cs
@@ -60,13 +60,16 @@ namespace GoodWin.Gui.ViewModels
             _listener = new GsiListenerService(3000);
             _listener.OnNewGameState += gs =>
             {
-                var clock = gs.Map?.ClockTime;
-                if (clock == null)
+                // ClockTime может отсутствовать в некоторых версиях GSI, поэтому
+                // используем GameTime в качестве резервного значения. Это гарантирует,
+                // что планировщик дебаффов продолжит работу даже при неполных данных.
+                double? time = gs.Map?.ClockTime ?? gs.Map?.GameTime;
+                if (time == null)
                 {
                     DebugLogService.Log("GSI map data missing");
                     return;
                 }
-                _scheduler.Update(clock.Value);
+                _scheduler.Update(time.Value);
                 System.Windows.Application.Current.Dispatcher.Invoke(() =>
                 {
                     EventLog.Add(DateTime.Now.ToString("T") + " - событие");


### PR DESCRIPTION
## Summary
- use GameTime as a fallback when ClockTime is missing so debuff scheduler continues updating

## Testing
- `dotnet build` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.)*

------
https://chatgpt.com/codex/tasks/task_e_6896b6941ff88322a249875d000fea01