### PR TITLE
feat: auto-detect Dota GSI configuration

### DIFF
--- a/GoodWin.Gui/ViewModels/MainViewModel.cs
+++ b/GoodWin.Gui/ViewModels/MainViewModel.cs
@@ -19,6 +19,7 @@ namespace GoodWin.Gui.ViewModels
     public partial class MainViewModel : ObservableObject
     {
         private readonly GsiListenerService _listener;
+        private readonly IDotaPathResolver _pathResolver;
         private readonly DebuffsRegistry _registry = new();
         private readonly DebuffScheduler _scheduler = new();
         private readonly DotaCommandService _commandService = new();
@@ -57,7 +58,8 @@ namespace GoodWin.Gui.ViewModels
 
         public MainViewModel()
         {
-            _listener = new GsiListenerService(3000);
+            _pathResolver = new DotaPathResolver();
+            _listener = new GsiListenerService(_pathResolver, 3000);
             _listener.OnNewGameState += gs =>
             {
                 // ClockTime может отсутствовать в некоторых версиях GSI, поэтому
@@ -77,6 +79,7 @@ namespace GoodWin.Gui.ViewModels
                     GsiStatus = "GSI активен";
                 });
             };
+            _pathResolver.EnsureConfigCreated();
             _listener.Start();
 
             _scheduler.DebuffSelectionPending += (s, e) => OnDebuffSelectionPending();

--- a/GoodWin.Tracker/DotaPathResolver.cs
+++ b/GoodWin.Tracker/DotaPathResolver.cs
@@ -1,0 +1,70 @@
+using System.IO;
+
+namespace GoodWin.Tracker
+{
+    /// <summary>
+    /// Searches for the Dota 2 installation and creates the
+    /// Game State Integration configuration if needed.
+    /// </summary>
+    public sealed class DotaPathResolver : IDotaPathResolver
+    {
+        public string? EnsureConfigCreated()
+        {
+            var cfgDir = FindCfgDirectory();
+            if (cfgDir is null)
+                return null;
+
+            var gsiDir = Path.Combine(cfgDir, "gamestate_integration");
+            if (!Directory.Exists(gsiDir))
+                Directory.CreateDirectory(gsiDir);
+
+            var cfgPath = Path.Combine(gsiDir, "gamestate_integration_GoodWinDebuff.cfg");
+            if (!File.Exists(cfgPath))
+            {
+                File.WriteAllText(cfgPath, BuildTemplate());
+            }
+            return cfgPath;
+        }
+
+        private static string? FindCfgDirectory()
+        {
+            foreach (var drive in DriveInfo.GetDrives())
+            {
+                try
+                {
+                    var path = Path.Combine(drive.RootDirectory.FullName,
+                        "Steam", "steamapps", "common", "dota 2 beta", "game", "dota", "cfg");
+                    if (Directory.Exists(path))
+                        return path;
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+            return null;
+        }
+
+        private static string BuildTemplate(int port = 3000)
+        {
+            return
+                "\"dota2cfg\"\n" +
+                "{\n" +
+                $"    \"uri\" \"http://localhost:{port}\"\n" +
+                "    \"timeout\" \"5.0\"\n" +
+                "    \"buffer\"  \"0.1\"\n" +
+                "    \"throttle\" \"0.1\"\n" +
+                "    \"heartbeat\" \"30.0\"\n" +
+                "    \"data\"\n" +
+                "    {\n" +
+                "        \"provider\" \"1\"\n" +
+                "        \"map\" \"1\"\n" +
+                "        \"player\" \"1\"\n" +
+                "        \"hero\" \"1\"\n" +
+                "        \"abilities\" \"1\"\n" +
+                "        \"items\" \"1\"\n" +
+                "    }\n" +
+                "}";
+        }
+    }
+}

--- a/GoodWin.Tracker/GsiListenerService.cs
+++ b/GoodWin.Tracker/GsiListenerService.cs
@@ -9,6 +9,7 @@ namespace GoodWin.Tracker
     /// </summary>
     public class GsiListenerService : IDisposable
     {
+        private readonly IDotaPathResolver _pathResolver;
         private GameStateListener _listener;
 
         /// <summary>
@@ -21,8 +22,9 @@ namespace GoodWin.Tracker
         /// </summary>
         public event Action<GameState>? OnNewGameState;
 
-        public GsiListenerService(int port = 3000)
+        public GsiListenerService(IDotaPathResolver pathResolver, int port = 3000)
         {
+            _pathResolver = pathResolver;
             _listener = new GameStateListener(port);
             _listener.NewGameState += HandleNewGameState;
         }
@@ -33,15 +35,13 @@ namespace GoodWin.Tracker
             OnNewGameState?.Invoke(gs);
         }
 
-        public bool GenerateConfig(string configName = "GoodWinDebuff") =>
-            _listener.GenerateGSIConfigFile(configName);
-
         /// <summary>
         /// Запускает прослушивание GSI. Если выбранный порт занят,
         /// пытается увеличить его до 5 раз.
         /// </summary>
         public bool Start(int maxAttempts = 5)
         {
+            _pathResolver.EnsureConfigCreated();
             for (int i = 0; i < maxAttempts; i++)
             {
                 if (_listener.Start())

--- a/GoodWin.Tracker/IDotaPathResolver.cs
+++ b/GoodWin.Tracker/IDotaPathResolver.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace GoodWin.Tracker
+{
+    /// <summary>
+    /// Resolves Dota 2 installation paths and ensures that
+    /// a Game State Integration configuration file exists.
+    /// </summary>
+    public interface IDotaPathResolver
+    {
+        /// <summary>
+        /// Ensures that the GSI configuration file for GoodWin exists.
+        /// </summary>
+        /// <returns>Full path to the configuration file or null if Dota 2 was not found.</returns>
+        string? EnsureConfigCreated();
+    }
+}


### PR DESCRIPTION
## Summary
- add `IDotaPathResolver` service to discover Dota 2 cfg folder and create GSI config
- hook `GsiListenerService` and `MainViewModel` to ensure config before starting listener

## Testing
- `dotnet build GoodWin.Tracker/GoodWin.Tracker.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896ce096ab8832285449f980ff7b9d8