### PR TITLE
Add match state model and player list UI

### DIFF
--- a/GoodWin.Gui/Views/HomeView.xaml
+++ b/GoodWin.Gui/Views/HomeView.xaml
@@ -4,7 +4,31 @@
     <StackPanel>
         <TextBlock Text="Главная" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" Foreground="{StaticResource TextBrush}" />
         <Border Style="{StaticResource Card}">
-            <TextBlock Text="Добро пожаловать в GoodWinFun" />
+            <StackPanel>
+                <TextBlock Text="Добро пожаловать в GoodWinFun" />
+                <TextBlock Text="Игроки:" Margin="0,8,0,4" />
+                <ItemsControl ItemsSource="{Binding Players}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Name}" Margin="0,0,8,0">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Foreground" Value="Green" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsAlly}" Value="False">
+                                                    <Setter Property="Foreground" Value="Red" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <TextBlock Text="{Binding HeroName}" Foreground="{StaticResource TextBrush}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
         </Border>
     </StackPanel>
 </UserControl>

--- a/GoodWin.Tracker/MatchState.cs
+++ b/GoodWin.Tracker/MatchState.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace GoodWin.Tracker;
+
+public enum MatchTeam
+{
+    Radiant,
+    Dire,
+    Unknown
+}
+
+public sealed class MatchPlayer
+{
+    public string Name { get; set; } = string.Empty;
+    public string? HeroName { get; set; }
+    public MatchTeam Team { get; set; }
+}
+
+public sealed class MatchState
+{
+    public IReadOnlyList<MatchPlayer> Players { get; init; } = new List<MatchPlayer>();
+    public double Time { get; init; }
+    public MatchTeam LocalTeam { get; init; } = MatchTeam.Unknown;
+}


### PR DESCRIPTION
## Summary
- convert raw GameState to new MatchState with players and time
- expose MatchState to listeners and update MainViewModel
- show players with ally/enemy marker on Home page

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896d1ac23648322a947249aa7f65dc8