### PR TITLE
Show detected paths and keybinds in UI

### DIFF
--- a/GoodWin.Gui/ViewModels/MainViewModel.cs
+++ b/GoodWin.Gui/ViewModels/MainViewModel.cs
@@ -33,6 +33,7 @@ namespace GoodWin.Gui.ViewModels
         public ObservableCollection<IDebuff> AllDebuffs { get; } = new();
         public ObservableCollection<string> DebugLog => DebugLogService.Entries;
         public ObservableCollection<PlayerDisplay> Players { get; } = new();
+        public ObservableCollection<PathDisplay> Paths { get; } = new();
 
         [ObservableProperty] private bool easyEnabled = true;
         [ObservableProperty] private bool mediumEnabled = true;
@@ -80,7 +81,9 @@ namespace GoodWin.Gui.ViewModels
                     GsiStatus = "GSI активен";
                 });
             };
-            _pathResolver.EnsureConfigCreated();
+            var cfgPath = _pathResolver.EnsureConfigCreated();
+            Paths.Add(new PathDisplay("GSI config", cfgPath ?? "не найден"));
+            Paths.Add(new PathDisplay("dotakeys_personal.lst", _keybindService.CurrentPath ?? "не найден"));
             _listener.Start();
 
             _scheduler.DebuffSelectionPending += (s, e) => OnDebuffSelectionPending();
@@ -380,4 +383,5 @@ namespace GoodWin.Gui.ViewModels
     }
 
     public record PlayerDisplay(string Name, string? HeroName, bool IsAlly);
+    public record PathDisplay(string Name, string Path);
 }

--- a/GoodWin.Gui/ViewModels/SettingsViewModel.cs
+++ b/GoodWin.Gui/ViewModels/SettingsViewModel.cs
@@ -1,88 +1,28 @@
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
-using GoodWin.Gui.Services;
+using GoodWin.Keybinds;
 
 namespace GoodWin.Gui.ViewModels
 {
     public partial class SettingsViewModel : ObservableObject
     {
-        private readonly UserSettingsService _service;
-
-        [ObservableProperty] private string firstSkill;
-        [ObservableProperty] private string secondSkill;
-        [ObservableProperty] private string thirdSkill;
-        [ObservableProperty] private string ultimate;
-        [ObservableProperty] private string consoleKey;
-        [ObservableProperty] private string chatKey;
-        [ObservableProperty] private string teamChatKey;
-
-        [ObservableProperty] private string itemSlot1;
-        [ObservableProperty] private string itemSlot2;
-        [ObservableProperty] private string itemSlot3;
-        [ObservableProperty] private string itemSlot4;
-        [ObservableProperty] private string itemSlot5;
-        [ObservableProperty] private string itemSlot6;
-
-        public IRelayCommand SaveCommand { get; }
-        public IRelayCommand ResetCommand { get; }
+        private readonly IKeybindService _keybinds;
+        public ObservableCollection<BindingDisplay> Bindings { get; } = new();
 
         public SettingsViewModel()
         {
-            _service = new UserSettingsService("usersettings.json");
-            var s = _service.Settings;
-            firstSkill = s.Controls.Abilities.Slot1;
-            secondSkill = s.Controls.Abilities.Slot2;
-            thirdSkill = s.Controls.Abilities.Slot3;
-            ultimate = s.Controls.Abilities.Ultimate;
-            consoleKey = s.Controls.ConsoleKey;
-            chatKey = s.Controls.ChatKey;
-            teamChatKey = s.Controls.TeamChatKey;
-            itemSlot1 = s.Controls.Items.Slot1;
-            itemSlot2 = s.Controls.Items.Slot2;
-            itemSlot3 = s.Controls.Items.Slot3;
-            itemSlot4 = s.Controls.Items.Slot4;
-            itemSlot5 = s.Controls.Items.Slot5;
-            itemSlot6 = s.Controls.Items.Slot6;
-            SaveCommand = new RelayCommand(Save);
-            ResetCommand = new RelayCommand(Reset);
+            _keybinds = new KeybindService(new SteamPathService());
+            Load();
+            _keybinds.BindingsChanged += (s, e) => Load();
         }
 
-        private void Save()
+        private void Load()
         {
-            var s = _service.Settings;
-            s.Controls.Abilities.Slot1 = FirstSkill;
-            s.Controls.Abilities.Slot2 = SecondSkill;
-            s.Controls.Abilities.Slot3 = ThirdSkill;
-            s.Controls.Abilities.Ultimate = Ultimate;
-            s.Controls.ConsoleKey = ConsoleKey;
-            s.Controls.ChatKey = ChatKey;
-            s.Controls.TeamChatKey = TeamChatKey;
-            s.Controls.Items.Slot1 = ItemSlot1;
-            s.Controls.Items.Slot2 = ItemSlot2;
-            s.Controls.Items.Slot3 = ItemSlot3;
-            s.Controls.Items.Slot4 = ItemSlot4;
-            s.Controls.Items.Slot5 = ItemSlot5;
-            s.Controls.Items.Slot6 = ItemSlot6;
-            _service.Save();
-        }
-
-        private void Reset()
-        {
-            _service.Reset();
-            var s = _service.Settings;
-            FirstSkill = s.Controls.Abilities.Slot1;
-            SecondSkill = s.Controls.Abilities.Slot2;
-            ThirdSkill = s.Controls.Abilities.Slot3;
-            Ultimate = s.Controls.Abilities.Ultimate;
-            ConsoleKey = s.Controls.ConsoleKey;
-            ChatKey = s.Controls.ChatKey;
-            TeamChatKey = s.Controls.TeamChatKey;
-            ItemSlot1 = s.Controls.Items.Slot1;
-            ItemSlot2 = s.Controls.Items.Slot2;
-            ItemSlot3 = s.Controls.Items.Slot3;
-            ItemSlot4 = s.Controls.Items.Slot4;
-            ItemSlot5 = s.Controls.Items.Slot5;
-            ItemSlot6 = s.Controls.Items.Slot6;
+            Bindings.Clear();
+            foreach (var kv in _keybinds.Bindings)
+                Bindings.Add(new BindingDisplay(kv.Key, kv.Value));
         }
     }
+
+    public record BindingDisplay(string Label, string Key);
 }

--- a/GoodWin.Gui/Views/HomeView.xaml
+++ b/GoodWin.Gui/Views/HomeView.xaml
@@ -30,6 +30,21 @@
                 </ItemsControl>
             </StackPanel>
         </Border>
+        <Border Style="{StaticResource Card}" Margin="0,16,0,0">
+            <StackPanel>
+                <TextBlock Text="Пути" />
+                <ItemsControl ItemsSource="{Binding Paths}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Margin="0,4,0,4">
+                                <TextBlock Text="{Binding Name}" FontWeight="Bold" />
+                                <TextBlock Text="{Binding Path}" TextWrapping="Wrap" Foreground="{StaticResource TextBrush}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
     </StackPanel>
 </UserControl>
 

--- a/GoodWin.Gui/Views/SettingsView.xaml
+++ b/GoodWin.Gui/Views/SettingsView.xaml
@@ -6,58 +6,14 @@
         <vm:SettingsViewModel />
     </UserControl.DataContext>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel HorizontalAlignment="Center">
-            <Grid HorizontalAlignment="Center">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="200" />
-                <ColumnDefinition Width="200" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <TextBlock Text="Первый скилл" Grid.Row="0" />
-            <TextBox Text="{Binding FirstSkill}" Grid.Column="1" Grid.Row="0" />
-            <TextBlock Text="Второй скилл" Grid.Row="1" />
-            <TextBox Text="{Binding SecondSkill}" Grid.Column="1" Grid.Row="1" />
-            <TextBlock Text="Третий скилл" Grid.Row="2" />
-            <TextBox Text="{Binding ThirdSkill}" Grid.Column="1" Grid.Row="2" />
-            <TextBlock Text="Ультимейт" Grid.Row="3" />
-            <TextBox Text="{Binding Ultimate}" Grid.Column="1" Grid.Row="3" />
-            <TextBlock Text="Предмет 1" Grid.Row="4" />
-            <TextBox Text="{Binding ItemSlot1}" Grid.Column="1" Grid.Row="4" />
-            <TextBlock Text="Предмет 2" Grid.Row="5" />
-            <TextBox Text="{Binding ItemSlot2}" Grid.Column="1" Grid.Row="5" />
-            <TextBlock Text="Предмет 3" Grid.Row="6" />
-            <TextBox Text="{Binding ItemSlot3}" Grid.Column="1" Grid.Row="6" />
-            <TextBlock Text="Предмет 4" Grid.Row="7" />
-            <TextBox Text="{Binding ItemSlot4}" Grid.Column="1" Grid.Row="7" />
-            <TextBlock Text="Предмет 5" Grid.Row="8" />
-            <TextBox Text="{Binding ItemSlot5}" Grid.Column="1" Grid.Row="8" />
-            <TextBlock Text="Предмет 6" Grid.Row="9" />
-            <TextBox Text="{Binding ItemSlot6}" Grid.Column="1" Grid.Row="9" />
-            <TextBlock Text="Консоль" Grid.Row="10" />
-            <TextBox Text="{Binding ConsoleKey}" Grid.Column="1" Grid.Row="10" />
-            <TextBlock Text="Открыть чат" Grid.Row="11" />
-            <TextBox Text="{Binding ChatKey}" Grid.Column="1" Grid.Row="11" />
-            <TextBlock Text="Общий чат" Grid.Row="12" />
-            <TextBox Text="{Binding TeamChatKey}" Grid.Column="1" Grid.Row="12" />
-        </Grid>
-            <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Center">
-                <Button Content="Сохранить" Command="{Binding SaveCommand}" Width="100" />
-                <Button Content="Сбросить" Command="{Binding ResetCommand}" Width="100" Margin="5,0,0,0" />
-            </StackPanel>
-        </StackPanel>
+        <DataGrid ItemsSource="{Binding Bindings}"
+                  AutoGenerateColumns="False"
+                  HeadersVisibility="Column"
+                  IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Действие" Binding="{Binding Label}" Width="*" />
+                <DataGridTextColumn Header="Клавиша" Binding="{Binding Key}" Width="*" />
+            </DataGrid.Columns>
+        </DataGrid>
     </ScrollViewer>
 </UserControl>

--- a/GoodWin.Keybinds/IKeybindService.cs
+++ b/GoodWin.Keybinds/IKeybindService.cs
@@ -5,4 +5,5 @@ public interface IKeybindService
     IReadOnlyDictionary<string, string> Bindings { get; }
     event EventHandler? BindingsChanged;
     void Reload();
+    string? CurrentPath { get; }
 }

--- a/GoodWin.Keybinds/KeybindService.cs
+++ b/GoodWin.Keybinds/KeybindService.cs
@@ -19,6 +19,8 @@ public sealed class KeybindService : IKeybindService, IDisposable
 
     public IReadOnlyDictionary<string, string> Bindings => _bindings;
 
+    public string? CurrentPath => _currentPath;
+
     public event EventHandler? BindingsChanged;
 
     public void Reload()


### PR DESCRIPTION
## Summary
- expose dotakeys file path via `IKeybindService`
- show detected Dota config paths on Home tab
- display key bindings from `dotakeys_personal.lst` in Settings tab

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: WindowsDesktop targets missing)*
- `dotnet workload install windowsdesktop` *(fails: workload ID not recognized)*
- `dotnet build GoodWin.Keybinds/GoodWin.Keybinds.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6896e79ecc8c8322b409fcdd4caef56c