### PR TITLE
Add manual Dota 2 path selection for GSI config

### DIFF
--- a/GoodWin.Gui/Views/HomeView.xaml
+++ b/GoodWin.Gui/Views/HomeView.xaml
@@ -1,6 +1,9 @@
 <UserControl x:Class="GoodWin.Gui.Views.HomeView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </UserControl.Resources>
     <StackPanel>
         <TextBlock Text="Главная" FontSize="20" FontWeight="Bold" Margin="0,0,0,16" Foreground="{StaticResource TextBrush}" />
         <Border Style="{StaticResource Card}">
@@ -43,6 +46,10 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
+                <Button Content="Указать вручную"
+                        Command="{Binding BrowseDotaPathCommand}"
+                        Visibility="{Binding ShowSpecifyPathButton, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        Margin="0,8,0,0" />
             </StackPanel>
         </Border>
     </StackPanel>

--- a/GoodWin.Tracker/DotaPathResolver.cs
+++ b/GoodWin.Tracker/DotaPathResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -11,9 +12,14 @@ namespace GoodWin.Tracker
     /// </summary>
     public sealed class DotaPathResolver : IDotaPathResolver
     {
-        public string? EnsureConfigCreated()
+        private string? _manualRoot;
+
+        public string? EnsureConfigCreated(string? manualRoot = null)
         {
-            var cfgDir = FindCfgDirectory();
+            if (!string.IsNullOrWhiteSpace(manualRoot))
+                _manualRoot = manualRoot;
+
+            var cfgDir = _manualRoot != null ? ResolveManualCfgDirectory(_manualRoot) : FindCfgDirectory();
             if (cfgDir is null)
                 return null;
 
@@ -27,6 +33,18 @@ namespace GoodWin.Tracker
                 File.WriteAllText(cfgPath, BuildTemplate());
             }
             return cfgPath;
+        }
+
+        private static string? ResolveManualCfgDirectory(string root)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+                return null;
+
+            if (root.EndsWith(Path.Combine("game", "dota", "cfg"), System.StringComparison.OrdinalIgnoreCase))
+                return Directory.Exists(root) ? root : null;
+
+            var candidate = Path.Combine(root, "game", "dota", "cfg");
+            return Directory.Exists(candidate) ? candidate : null;
         }
 
         private static string? FindCfgDirectory()

--- a/GoodWin.Tracker/IDotaPathResolver.cs
+++ b/GoodWin.Tracker/IDotaPathResolver.cs
@@ -11,7 +11,8 @@ namespace GoodWin.Tracker
         /// <summary>
         /// Ensures that the GSI configuration file for GoodWin exists.
         /// </summary>
+        /// <param name="manualRoot">Optional path to the Dota 2 installation.</param>
         /// <returns>Full path to the configuration file or null if Dota 2 was not found.</returns>
-        string? EnsureConfigCreated();
+        string? EnsureConfigCreated(string? manualRoot = null);
     }
 }


### PR DESCRIPTION
## Summary
- Allow specifying Dota 2 installation path when automatic search fails
- Show "Указать вручную" button to pick the path and create GSI config
- Expand path resolver to remember user-specified location

## Testing
- `dotnet build -c Release -p:EnableWindowsTargeting=true` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop". The default SDK resolver failed to resolve the SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6896ed9679308322b0d6ccfa19c14c24