### PR TITLE
Fix DotaPathResolver compilation issues

### DIFF
--- a/GoodWin.Tracker/DotaPathResolver.cs
+++ b/GoodWin.Tracker/DotaPathResolver.cs
@@ -82,27 +82,20 @@ namespace GoodWin.Tracker
 
         private static IEnumerable<string> EnumerateLibraries()
         {
-            try
-            {
-                using var key = Registry.CurrentUser.OpenSubKey(@"Software\Valve\Steam");
-                var root = key?.GetValue("SteamPath") as string;
-                if (string.IsNullOrWhiteSpace(root))
-                    yield break;
+            using var key = Registry.CurrentUser.OpenSubKey(@"Software\Valve\Steam");
+            var root = key?.GetValue("SteamPath") as string;
+            if (string.IsNullOrWhiteSpace(root))
+                yield break;
 
-                root = root.Replace('/', '\\');
-                yield return root;
+            root = root.Replace('/', '\\');
+            yield return root;
 
-                var vdf = Path.Combine(root, "steamapps", "libraryfolders.vdf");
-                if (!File.Exists(vdf))
-                    yield break;
+            var vdf = Path.Combine(root, "steamapps", "libraryfolders.vdf");
+            if (!File.Exists(vdf))
+                yield break;
 
-                foreach (var lib in ParseLibraryFolders(vdf))
-                    yield return lib;
-            }
-            catch
-            {
-                // ignored
-            }
+            foreach (var lib in ParseLibraryFolders(vdf))
+                yield return lib;
         }
 
         private static IEnumerable<string> ParseLibraryFolders(string vdfPath)
@@ -113,7 +106,7 @@ namespace GoodWin.Tracker
                 if (trimmed.Length == 0)
                     continue;
 
-                var match = Regex.Match(trimmed, "^\"(?:path|contentid|\\d+)\"\s*\"(?<p>[^\"]+)\"");
+                var match = Regex.Match(trimmed, @"^""(?:path|contentid|\d+)""\s*""(?<p>[^""]+)""");
                 if (match.Success)
                 {
                     var path = match.Groups["p"].Value


### PR DESCRIPTION
## Summary
- avoid yielding within try-catch in EnumerateLibraries
- correct regex string for parsing Steam library folders

## Testing
- `dotnet build -c Release` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*
- `dotnet build GoodWin.Tracker/GoodWin.Tracker.csproj -c Release` *(fails: MSB4019: The imported project ... WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896ef829e48832297d8fa8ee64a58c7