### PR TITLE
Add keybind editing UI and serialization support

### DIFF
--- a/GoodWin.Gui/Validation/KeyValidationRule.cs
+++ b/GoodWin.Gui/Validation/KeyValidationRule.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows.Controls;
+
+namespace GoodWin.Gui.Validation;
+
+public class KeyValidationRule : ValidationRule
+{
+    private static readonly HashSet<string> Special = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "SPACE","RETURN","ESCAPE","TAB","BACKSPACE","OEM3",
+        "UPARROW","DOWNARROW","LEFTARROW","RIGHTARROW",
+        "MOUSE1","MOUSE2","MWHEELUP","MWHEELDOWN"
+    };
+
+    public override ValidationResult Validate(object value, CultureInfo culture)
+    {
+        var text = (value as string)?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(text)) return ValidationResult.ValidResult;
+        if (text.Length == 1 && char.IsLetterOrDigit(text[0])) return ValidationResult.ValidResult;
+        if (Special.Contains(text.ToUpperInvariant())) return ValidationResult.ValidResult;
+        return new ValidationResult(false, "Недопустимая клавиша");
+    }
+}

--- a/GoodWin.Gui/ViewModels/SettingsViewModel.cs
+++ b/GoodWin.Gui/ViewModels/SettingsViewModel.cs
@@ -1,5 +1,11 @@
+using System.Collections.Generic;
+
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using GoodWin.Keybinds;
 
 namespace GoodWin.Gui.ViewModels
@@ -7,22 +13,93 @@ namespace GoodWin.Gui.ViewModels
     public partial class SettingsViewModel : ObservableObject
     {
         private readonly IKeybindService _keybinds;
-        public ObservableCollection<BindingDisplay> Bindings { get; } = new();
+        private readonly List<KeybindItemViewModel> _allItems = new();
+
+        public ObservableCollection<CategoryViewModel> Categories { get; } = new();
+
+        [ObservableProperty]
+        private CategoryViewModel? selectedCategory;
+
+        public IAsyncRelayCommand SaveCommand { get; }
+        public IRelayCommand ReloadCommand { get; }
 
         public SettingsViewModel()
         {
             _keybinds = new KeybindService(new SteamPathService());
+            SaveCommand = new AsyncRelayCommand(SaveAsync);
+            ReloadCommand = new RelayCommand(() => _keybinds.Reload());
             Load();
             _keybinds.BindingsChanged += (s, e) => Load();
         }
 
         private void Load()
         {
-            Bindings.Clear();
-            foreach (var kv in _keybinds.Bindings)
-                Bindings.Add(new BindingDisplay(kv.Key, kv.Value));
+            Categories.Clear();
+            _allItems.Clear();
+            foreach (var item in _keybinds.Entries.Select(e => new KeybindItemViewModel(e)))
+            {
+                item.PropertyChanged += Item_PropertyChanged;
+                _allItems.Add(item);
+            }
+            var groups = _allItems.GroupBy(i => i.Category).OrderBy(g => g.Key);
+            foreach (var g in groups)
+                Categories.Add(new CategoryViewModel(g.Key, g));
+            SelectedCategory = Categories.FirstOrDefault();
+            UpdateConflicts();
+        }
+
+        private void Item_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(KeybindItemViewModel.Key))
+                UpdateConflicts();
+        }
+
+        private void UpdateConflicts()
+        {
+            foreach (var item in _allItems)
+                item.HasConflict = false;
+            var groups = _allItems.GroupBy(i => i.Key).Where(g => !string.IsNullOrWhiteSpace(g.Key) && g.Count() > 1);
+            foreach (var g in groups)
+                foreach (var item in g)
+                    item.HasConflict = true;
+        }
+
+        private async Task SaveAsync()
+        {
+            var entries = _allItems.Select(i => { i.Model.Key = i.Key; return i.Model; }).ToList();
+            await _keybinds.SaveAsync(entries);
         }
     }
 
-    public record BindingDisplay(string Label, string Key);
+    public sealed class CategoryViewModel
+    {
+        public string Name { get; }
+        public ObservableCollection<KeybindItemViewModel> Items { get; }
+
+        public CategoryViewModel(string name, IEnumerable<KeybindItemViewModel> items)
+        {
+            Name = name;
+            Items = new ObservableCollection<KeybindItemViewModel>(items);
+        }
+    }
+
+    public partial class KeybindItemViewModel : ObservableObject
+    {
+        public KeybindEntry Model { get; }
+        public string Category { get; }
+        public string FriendlyName => DotaFriendly.MakeFriendly(Model);
+
+        [ObservableProperty]
+        private string key;
+
+        [ObservableProperty]
+        private bool hasConflict;
+
+        public KeybindItemViewModel(KeybindEntry m)
+        {
+            Model = m;
+            Category = DotaCategories.ToCategory(m.Panel);
+            key = m.Key ?? string.Empty;
+        }
+    }
 }

--- a/GoodWin.Gui/Views/SettingsView.xaml
+++ b/GoodWin.Gui/Views/SettingsView.xaml
@@ -1,19 +1,52 @@
 <UserControl x:Class="GoodWin.Gui.Views.SettingsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:vm="clr-namespace:GoodWin.Gui.ViewModels">
+             xmlns:vm="clr-namespace:GoodWin.Gui.ViewModels"
+             xmlns:val="clr-namespace:GoodWin.Gui.Validation">
     <UserControl.DataContext>
         <vm:SettingsViewModel />
     </UserControl.DataContext>
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <DataGrid ItemsSource="{Binding Bindings}"
-                  AutoGenerateColumns="False"
-                  HeadersVisibility="Column"
-                  IsReadOnly="True">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="Действие" Binding="{Binding Label}" Width="*" />
-                <DataGridTextColumn Header="Клавиша" Binding="{Binding Key}" Width="*" />
-            </DataGrid.Columns>
-        </DataGrid>
-    </ScrollViewer>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <Button Content="Reload" Command="{Binding ReloadCommand}" Margin="0,0,5,0" />
+            <Button Content="Save" Command="{Binding SaveCommand}" />
+        </StackPanel>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="200"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <ListBox ItemsSource="{Binding Categories}" SelectedItem="{Binding SelectedCategory}" DisplayMemberPath="Name" />
+            <DataGrid Grid.Column="1"
+                      ItemsSource="{Binding SelectedCategory.Items}"
+                      AutoGenerateColumns="False" HeadersVisibility="Column">
+                <DataGrid.RowStyle>
+                    <Style TargetType="DataGridRow">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasConflict}" Value="True">
+                                <Setter Property="Background" Value="#FFFFC0C0"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </DataGrid.RowStyle>
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Действие" Binding="{Binding FriendlyName}" IsReadOnly="True" Width="*"/>
+                    <DataGridTextColumn Header="Клавиша" Width="*">
+                        <DataGridTextColumn.Binding>
+                            <Binding Path="Key" UpdateSourceTrigger="PropertyChanged">
+                                <Binding.ValidationRules>
+                                    <val:KeyValidationRule />
+                                </Binding.ValidationRules>
+                            </Binding>
+                        </DataGridTextColumn.Binding>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Header="Команда" Binding="{Binding Model.Action}" IsReadOnly="True" Width="*"/>
+                </DataGrid.Columns>
+            </DataGrid>
+        </Grid>
+    </Grid>
 </UserControl>

--- a/GoodWin.Keybinds/DotaCategories.cs
+++ b/GoodWin.Keybinds/DotaCategories.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace GoodWin.Keybinds;
+
+public static class DotaCategories
+{
+    private static readonly Dictionary<string, string> PanelToCategory = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["#DOTA_KEYBIND_MENU_ABILITIES"] = "Кнопки для скиллов",
+        ["#DOTA_KEYBIND_MENU_ITEMS"] = "Кнопки предметов",
+        ["#DOTA_KEYBIND_MENU_UNIT"] = "Управление юнитами",
+        ["#DOTA_KEYBIND_MENU_INTERFACE"] = "Кнопки интерфейса",
+        ["#DOTA_KEYBIND_MENU_CHAT"] = "Чат и коммуникация",
+        ["#DOTA_KEYBIND_MENU_PLAYER"] = "Игровые действия",
+        ["#DOTA_KEYBIND_MENU_CAMERA"] = "Камера",
+        ["#DOTA_KEYBIND_MENU_SHOP"] = "Магазин",
+        ["#DOTA_KEYBIND_MENU_CONTROLGROUPS"] = "Группы управления",
+        ["#DOTA_KEYBIND_MENU_SPECTATOR"] = "Зрительский режим",
+    };
+
+    public static string ToCategory(string panel)
+        => PanelToCategory.TryGetValue(panel, out var c) ? c : "Прочее";
+}
+

--- a/GoodWin.Keybinds/DotaFriendly.cs
+++ b/GoodWin.Keybinds/DotaFriendly.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+using System.Text.RegularExpressions;
+
+namespace GoodWin.Keybinds;
+
+public static class DotaFriendly
+{
+    private static readonly Dictionary<string, string> DescriptionToRu = new()
+    {
+        ["#DOTA_Ability1"] = "Первый скилл",
+        ["#DOTA_Ability2"] = "Второй скилл",
+        ["#DOTA_Ability3"] = "Третий скилл",
+        ["#DOTA_Ability4"] = "Ультимейт",
+        ["#DOTA_InventorySlot1"] = "Предмет 1",
+        ["#DOTA_InventorySlot2"] = "Предмет 2",
+        ["#DOTA_InventorySlot3"] = "Предмет 3",
+        ["#DOTA_InventorySlot4"] = "Предмет 4",
+        ["#DOTA_InventorySlot5"] = "Предмет 5",
+        ["#DOTA_InventorySlot6"] = "Предмет 6",
+    };
+
+    public static string MakeFriendly(KeybindEntry e)
+    {
+        if (DescriptionToRu.TryGetValue(e.Description, out var ru)) return ru;
+        if (!string.IsNullOrWhiteSpace(e.Name)) return SplitCamelCase(e.Name);
+        if (!string.IsNullOrWhiteSpace(e.Action)) return e.Action.Replace("_", " ");
+        return e.Label;
+    }
+
+    private static string SplitCamelCase(string s) =>
+        Regex.Replace(s, "([a-z])([A-Z])", "$1 $2").Trim();
+}
+

--- a/GoodWin.Keybinds/IKeybindService.cs
+++ b/GoodWin.Keybinds/IKeybindService.cs
@@ -1,9 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace GoodWin.Keybinds;
 
 public interface IKeybindService
 {
     IReadOnlyDictionary<string, string> Bindings { get; }
+    IReadOnlyList<KeybindEntry> Entries { get; }
     event EventHandler? BindingsChanged;
     void Reload();
+    Task SaveAsync(IEnumerable<KeybindEntry> entries);
     string? CurrentPath { get; }
 }


### PR DESCRIPTION
## Summary
- categorize Dota keybind panels and map friendly names
- add editable keybind table with validation, conflict highlighting, and Save/Reload
- implement keybind serialization with backups and interface extensions

## Testing
- `dotnet build GoodWin.Keybinds/GoodWin.Keybinds.csproj`
- `dotnet build GoodWin.Gui/GoodWin.Gui.csproj -p:EnableWindowsTargeting=true` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*


------
https://chatgpt.com/codex/tasks/task_e_6896f4ad48f483229814f17d915cded5