### PR TITLE
Fix missing StringComparer namespace

### DIFF
--- a/GoodWin.Gui/Validation/KeyValidationRule.cs
+++ b/GoodWin.Gui/Validation/KeyValidationRule.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Windows.Controls;


### PR DESCRIPTION
## Summary
- Add System namespace in KeyValidationRule to resolve StringComparer reference

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6896f6d5e3548322a86023529f15d750