### PR TITLE
Add buffered input lag with interpolation

### DIFF
--- a/GoodWin.Utils/InputHookHost.cs
+++ b/GoodWin.Utils/InputHookHost.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
@@ -30,6 +32,30 @@ namespace GoodWin.Utils
         private int _blockWheel;
         private POINT _lastMousePt;
         private bool _hasLastPt;
+
+        private struct KeyLagEvent
+        {
+            public int Vk;
+            public bool Up;
+            public long Time;
+        }
+
+        private struct MouseLagSample
+        {
+            public int X;
+            public int Y;
+            public long Time;
+        }
+
+        private readonly ConcurrentQueue<KeyLagEvent> _keyLagQueue = new();
+        private readonly ConcurrentQueue<MouseLagSample> _mouseLagQueue = new();
+        private readonly Stopwatch _lagStopwatch = Stopwatch.StartNew();
+        private MouseLagSample _lastLagSample;
+        private bool _hasLastLagSample;
+        private Timer? _lagTimer;
+
+        private const double LagDelayMs = 330;
+        private const double MaxBufferMs = 600;
 
         private InputHookHost()
         {
@@ -64,6 +90,77 @@ namespace GoodWin.Utils
             _thread.Start();
         }
 
+        private void EnsureLagTimer()
+        {
+            if (_lagTimer == null)
+                _lagTimer = new Timer(LagTick, null, 0, 8);
+        }
+
+        private void StopLagTimer()
+        {
+            _lagTimer?.Dispose();
+            _lagTimer = null;
+            _hasLastLagSample = false;
+            while (_keyLagQueue.TryDequeue(out _)) { }
+            while (_mouseLagQueue.TryDequeue(out _)) { }
+        }
+
+        private void PruneKeyQueue(long threshold)
+        {
+            while (_keyLagQueue.TryPeek(out var e) && e.Time < threshold)
+                _keyLagQueue.TryDequeue(out _);
+        }
+
+        private void PruneMouseQueue(long threshold)
+        {
+            while (_mouseLagQueue.TryPeek(out var e) && e.Time < threshold)
+                _mouseLagQueue.TryDequeue(out _);
+        }
+
+        private void LagTick(object? state)
+        {
+            long target = _lagStopwatch.ElapsedMilliseconds - (long)LagDelayMs;
+
+            while (_keyLagQueue.TryPeek(out var ke) && ke.Time <= target)
+            {
+                _keyLagQueue.TryDequeue(out ke);
+                keybd_event((byte)ke.Vk, 0, ke.Up ? KEYEVENTF_KEYUP : 0, 0);
+            }
+
+            while (_mouseLagQueue.TryPeek(out var me) && me.Time <= target)
+            {
+                _mouseLagQueue.TryDequeue(out me);
+                _lastLagSample = me;
+                _hasLastLagSample = true;
+            }
+
+            if (_hasLastLagSample)
+            {
+                int x, y;
+                if (_mouseLagQueue.TryPeek(out var next))
+                {
+                    double t0 = _lastLagSample.Time;
+                    double t1 = next.Time;
+                    double f = t1 == t0 ? 1 : (target - t0) / (t1 - t0);
+                    if (f < 0) f = 0; if (f > 1) f = 1;
+                    x = (int)Math.Round(_lastLagSample.X + (next.X - _lastLagSample.X) * f);
+                    y = (int)Math.Round(_lastLagSample.Y + (next.Y - _lastLagSample.Y) * f);
+                }
+                else
+                {
+                    x = _lastLagSample.X;
+                    y = _lastLagSample.Y;
+                }
+                Cursor.Position = new Point(x, y);
+            }
+
+            long cutoff = _lagStopwatch.ElapsedMilliseconds - (long)MaxBufferMs;
+            PruneKeyQueue(cutoff);
+            PruneMouseQueue(cutoff);
+            if (_hasLastLagSample && _lastLagSample.Time < cutoff)
+                _hasLastLagSample = false;
+        }
+
         private IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam)
         {
             if (nCode >= 0)
@@ -77,13 +174,23 @@ namespace GoodWin.Utils
                 if (_blockAllKeys > 0 || blocked)
                     return new IntPtr(1);
                 if (_inputLag > 0)
-                    Thread.Sleep(500);
+                {
+                    bool isUp = wParam == (IntPtr)WM_KEYUP || wParam == (IntPtr)WM_SYSKEYUP;
+                    long now = _lagStopwatch.ElapsedMilliseconds;
+                    _keyLagQueue.Enqueue(new KeyLagEvent { Vk = vk, Up = isUp, Time = now });
+                    PruneKeyQueue(now - (long)MaxBufferMs);
+                    return new IntPtr(1);
+                }
             }
             return CallNextHookEx(_keyboardHook, nCode, wParam, lParam);
         }
 
         private const int WM_MOUSEMOVE = 0x0200;
         private const int WM_MOUSEWHEEL = 0x020A;
+        private const int WM_KEYDOWN = 0x0100;
+        private const int WM_KEYUP = 0x0101;
+        private const int WM_SYSKEYDOWN = 0x0104;
+        private const int WM_SYSKEYUP = 0x0105;
         private const uint MOUSEEVENTF_MOVE = 0x0001;
         private const uint LLMHF_INJECTED = 0x00000001;
         private const uint LLMHF_LOWER_IL_INJECTED = 0x00000002;
@@ -114,13 +221,19 @@ namespace GoodWin.Utils
 
                     if (!injected)
                     {
+                        if (_mouseLag > 0)
+                        {
+                            long now = _lagStopwatch.ElapsedMilliseconds;
+                            _mouseLagQueue.Enqueue(new MouseLagSample { X = data.pt.x, Y = data.pt.y, Time = now });
+                            PruneMouseQueue(now - (long)MaxBufferMs);
+                            return new IntPtr(1);
+                        }
+
                         if (!_hasLastPt)
                         {
                             _lastMousePt = data.pt;
                             _hasLastPt = true;
                         }
-                        if (_mouseLag > 0)
-                            Thread.Sleep(200);
                         int screenHeight = Screen.PrimaryScreen.Bounds.Height;
                         if (data.pt.y <= 0 || data.pt.y >= screenHeight - 1)
                         {
@@ -228,17 +341,31 @@ namespace GoodWin.Utils
         public void SetMouseLag(bool on)
         {
             if (on)
-                Interlocked.Increment(ref _mouseLag);
-            else if (Interlocked.Decrement(ref _mouseLag) < 0)
+            {
+                if (Interlocked.Increment(ref _mouseLag) == 1)
+                    EnsureLagTimer();
+            }
+            else if (Interlocked.Decrement(ref _mouseLag) <= 0)
+            {
                 _mouseLag = 0;
+                if (_inputLag <= 0)
+                    StopLagTimer();
+            }
         }
 
         public void SetInputLag(bool on)
         {
             if (on)
-                Interlocked.Increment(ref _inputLag);
-            else if (Interlocked.Decrement(ref _inputLag) < 0)
+            {
+                if (Interlocked.Increment(ref _inputLag) == 1)
+                    EnsureLagTimer();
+            }
+            else if (Interlocked.Decrement(ref _inputLag) <= 0)
+            {
                 _inputLag = 0;
+                if (_mouseLag <= 0)
+                    StopLagTimer();
+            }
         }
 
         public void SetCameraWheelBlocked(bool on)
@@ -253,6 +380,7 @@ namespace GoodWin.Utils
         {
             if (_keyboardHook != IntPtr.Zero) UnhookWindowsHookEx(_keyboardHook);
             if (_mouseHook != IntPtr.Zero) UnhookWindowsHookEx(_mouseHook);
+            StopLagTimer();
             Application.ExitThread();
             _thread = null;
         }


### PR DESCRIPTION
## Summary
- queue keyboard and mouse events with timestamps instead of thread sleeps
- play back buffered input via 120 Hz timer with 330 ms delay and 600 ms cap
- allow enabling/disabling lag buffers through SetMouseLag/SetInputLag

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" on this environment)*


------
https://chatgpt.com/codex/tasks/task_e_6896f95eaa108322a1af954cc4941762