### PR TITLE
Fix Timer ambiguity in InputHookHost

### DIFF
--- a/GoodWin.Utils/InputHookHost.cs
+++ b/GoodWin.Utils/InputHookHost.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
+using Timer = System.Threading.Timer;
 
 namespace GoodWin.Utils
 {


### PR DESCRIPTION
## Summary
- Disambiguate `Timer` usage in `InputHookHost` by aliasing `System.Threading.Timer`

## Testing
- `dotnet build GoodWin.Utils/GoodWin.Utils.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896fccc3b488322bbf1adcbf0f4968f