### PR TITLE
Propagate port for GSI config resolution

### DIFF
--- a/GoodWin.Gui/ViewModels/MainViewModel.cs
+++ b/GoodWin.Gui/ViewModels/MainViewModel.cs
@@ -85,7 +85,7 @@ namespace GoodWin.Gui.ViewModels
                     GsiStatus = "GSI активен";
                 });
             };
-            var cfgPath = _pathResolver.EnsureConfigCreated();
+            var cfgPath = _pathResolver.EnsureConfigCreated(null, _listener.Port);
             Paths.Add(new PathDisplay("GSI config", cfgPath ?? "не найден"));
             Paths.Add(new PathDisplay("dotakeys_personal.lst", _keybindService.CurrentPath ?? "не найден"));
             ShowSpecifyPathButton = cfgPath is null;
@@ -125,7 +125,7 @@ namespace GoodWin.Gui.ViewModels
             using var dialog = new FolderBrowserDialog { Description = "Укажите папку Dota 2" };
             if (dialog.ShowDialog() == DialogResult.OK)
             {
-                var cfg = _pathResolver.EnsureConfigCreated(dialog.SelectedPath);
+                var cfg = _pathResolver.EnsureConfigCreated(dialog.SelectedPath, _listener.Port);
                 var index = Paths.ToList().FindIndex(p => p.Name == "GSI config");
                 if (index >= 0)
                     Paths[index] = new PathDisplay("GSI config", cfg ?? "не найден");

--- a/GoodWin.Tracker/DotaPathResolver.cs
+++ b/GoodWin.Tracker/DotaPathResolver.cs
@@ -14,7 +14,7 @@ namespace GoodWin.Tracker
     {
         private string? _manualRoot;
 
-        public string? EnsureConfigCreated(string? manualRoot = null)
+        public string? EnsureConfigCreated(string? manualRoot, int port)
         {
             if (!string.IsNullOrWhiteSpace(manualRoot))
                 _manualRoot = manualRoot;
@@ -28,10 +28,7 @@ namespace GoodWin.Tracker
                 Directory.CreateDirectory(gsiDir);
 
             var cfgPath = Path.Combine(gsiDir, "gamestate_integration_GoodWinDebuff.cfg");
-            if (!File.Exists(cfgPath))
-            {
-                File.WriteAllText(cfgPath, BuildTemplate());
-            }
+            File.WriteAllText(cfgPath, BuildTemplate(port));
             return cfgPath;
         }
 
@@ -117,7 +114,7 @@ namespace GoodWin.Tracker
             }
         }
 
-        private static string BuildTemplate(int port = 3000)
+        private static string BuildTemplate(int port)
         {
             return
                 "\"dota2cfg\"\n" +

--- a/GoodWin.Tracker/GsiListenerService.cs
+++ b/GoodWin.Tracker/GsiListenerService.cs
@@ -82,9 +82,15 @@ namespace GoodWin.Tracker
         /// </summary>
         public bool Start(int maxAttempts = 5)
         {
-            _pathResolver.EnsureConfigCreated();
             for (int i = 0; i < maxAttempts; i++)
             {
+                var cfgPath = _pathResolver.EnsureConfigCreated(null, _listener.Port);
+                if (cfgPath is null)
+                {
+                    Console.WriteLine("[GSI] Dota 2 path not found; config not created.");
+                    return false;
+                }
+
                 if (_listener.Start())
                     return true;
 

--- a/GoodWin.Tracker/IDotaPathResolver.cs
+++ b/GoodWin.Tracker/IDotaPathResolver.cs
@@ -12,7 +12,8 @@ namespace GoodWin.Tracker
         /// Ensures that the GSI configuration file for GoodWin exists.
         /// </summary>
         /// <param name="manualRoot">Optional path to the Dota 2 installation.</param>
+        /// <param name="port">Port for the local GSI HTTP listener.</param>
         /// <returns>Full path to the configuration file or null if Dota 2 was not found.</returns>
-        string? EnsureConfigCreated(string? manualRoot = null);
+        string? EnsureConfigCreated(string? manualRoot, int port);
     }
 }


### PR DESCRIPTION
## Summary
- pass port parameter into Dota GSI config resolver
- regenerate config on each start attempt and log when path missing
- forward listener port from GUI when creating config

## Testing
- `dotnet build GoodWinDebuff.sln -p:EnableWindowsTargeting=true` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*
- `dotnet workload install windowsdesktop` *(fails: Workload ID windowsdesktop is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68972edaec9c8322b0d432116eea7746