### PR TITLE
Add JoyCommandService self-test and fallback path

### DIFF
--- a/GoodWin.Gui/Services/DotaCommandService.cs
+++ b/GoodWin.Gui/Services/DotaCommandService.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using GoodWin.Utils;
+using GoodWin.Gui.Views;
 
 namespace GoodWin.Gui.Services
 {
     public class DotaCommandService
     {
+        public bool ConsoleDebuffsEnabled { get; private set; } = true;
+
         public async Task InitializeCommandsAsync(CancellationToken token)
         {
             var start = DateTime.UtcNow;
@@ -19,6 +23,18 @@ namespace GoodWin.Gui.Services
             }
 
             await JoyCommandService.Instance.InitializeBindingsAsync(token);
+
+            if (!JoyCommandService.Instance.IsOperational || !JoyCommandService.Instance.SelfTest())
+            {
+                ConsoleDebuffsEnabled = false;
+                DebugLogService.Log("JoyCommandService unavailable. Console debuffs disabled.");
+                Application.Current?.Dispatcher.Invoke(() =>
+                {
+                    var win = new DebuffNotificationWindow("ViGEm недоступен", "Консольные дебаффы отключены");
+                    win.Show();
+                    Task.Delay(3000).ContinueWith(_ => win.Dispatcher.Invoke(win.Close));
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add IsOperational flag and DebugLog logging in JoyCommandService
- implement self-test and InputHookHost fallback for console commands
- guard DotaCommandService against unavailable JoyCommandService with user notification

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68973410de008322959d94c3d512a123