### PR TITLE
Validate Dota 2 root path before generating config

### DIFF
--- a/GoodWin.Gui/ViewModels/MainViewModel.cs
+++ b/GoodWin.Gui/ViewModels/MainViewModel.cs
@@ -138,6 +138,12 @@ namespace GoodWin.Gui.ViewModels
             using var dialog = new FolderBrowserDialog { Description = "Укажите папку Dota 2" };
             if (dialog.ShowDialog() == DialogResult.OK)
             {
+                if (!_pathResolver.IsValidRoot(dialog.SelectedPath))
+                {
+                    MessageBox.Show("Указан неверный путь к Dota 2", "Ошибка", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
+
                 var cfg = _pathResolver.EnsureConfigCreated(dialog.SelectedPath, _listener.Port);
                 var index = Paths.ToList().FindIndex(p => p.Name == "GSI config");
                 if (index >= 0)

--- a/GoodWin.Tracker/DotaPathResolver.cs
+++ b/GoodWin.Tracker/DotaPathResolver.cs
@@ -19,6 +19,9 @@ namespace GoodWin.Tracker
             if (!string.IsNullOrWhiteSpace(manualRoot))
                 _manualRoot = manualRoot;
 
+            if (_manualRoot != null && !IsValidRoot(_manualRoot))
+                return null;
+
             var cfgDir = _manualRoot != null ? ResolveManualCfgDirectory(_manualRoot) : FindCfgDirectory();
             if (cfgDir is null)
                 return null;
@@ -37,11 +40,23 @@ namespace GoodWin.Tracker
             if (string.IsNullOrWhiteSpace(root))
                 return null;
 
-            if (root.EndsWith(Path.Combine("game", "dota", "cfg"), System.StringComparison.OrdinalIgnoreCase))
+            var exePath = Path.Combine(root, "game", "bin", "win64", "dota2.exe");
+            if (!File.Exists(exePath))
+                return null;
+
+            if (root.EndsWith(Path.Combine("game", "dota", "cfg"), StringComparison.OrdinalIgnoreCase))
                 return Directory.Exists(root) ? root : null;
 
             var candidate = Path.Combine(root, "game", "dota", "cfg");
             return Directory.Exists(candidate) ? candidate : null;
+        }
+
+        public bool IsValidRoot(string root)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+                return false;
+            var exePath = Path.Combine(root, "game", "bin", "win64", "dota2.exe");
+            return File.Exists(exePath);
         }
 
         private static string? FindCfgDirectory()

--- a/GoodWin.Tracker/IDotaPathResolver.cs
+++ b/GoodWin.Tracker/IDotaPathResolver.cs
@@ -15,5 +15,12 @@ namespace GoodWin.Tracker
         /// <param name="port">Port for the local GSI HTTP listener.</param>
         /// <returns>Full path to the configuration file or null if Dota 2 was not found.</returns>
         string? EnsureConfigCreated(string? manualRoot, int port);
+
+        /// <summary>
+        /// Checks whether the supplied root path points to a valid Dota 2 installation.
+        /// </summary>
+        /// <param name="root">Path to the Dota 2 root directory.</param>
+        /// <returns><c>true</c> if the installation appears valid; otherwise, <c>false</c>.</returns>
+        bool IsValidRoot(string root);
     }
 }


### PR DESCRIPTION
## Summary
- check for `dota2.exe` when resolving manual Dota path and expose `IsValidRoot`
- validate user-provided Dota path in UI and show an error when invalid
- call `IsValidRoot` before creating GSI config

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet build GoodWin.Tracker/GoodWin.Tracker.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897366357c4832294b58c895ceaf2c3