### PR TITLE
Add keybind preset import/export functionality

### DIFF
--- a/GoodWin.Gui/GoodWin.Gui.csproj
+++ b/GoodWin.Gui/GoodWin.Gui.csproj
@@ -21,4 +21,10 @@
     <ProjectReference Include="..\GoodWin.Keybinds\GoodWin.Keybinds.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Presets/*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/GoodWin.Gui/Presets/asdf.json
+++ b/GoodWin.Gui/Presets/asdf.json
@@ -1,0 +1,14 @@
+{
+  "Ability1": "A",
+  "Ability2": "S",
+  "Ability3": "D",
+  "Ability4": "F",
+  "Ability5": "G",
+  "Ability6": "H",
+  "Item1": "Z",
+  "Item2": "X",
+  "Item3": "C",
+  "Item4": "V",
+  "Item5": "B",
+  "Item6": "N"
+}

--- a/GoodWin.Gui/Presets/esdf.json
+++ b/GoodWin.Gui/Presets/esdf.json
@@ -1,0 +1,14 @@
+{
+  "Ability1": "E",
+  "Ability2": "S",
+  "Ability3": "D",
+  "Ability4": "F",
+  "Ability5": "G",
+  "Ability6": "H",
+  "Item1": "Z",
+  "Item2": "X",
+  "Item3": "C",
+  "Item4": "V",
+  "Item5": "B",
+  "Item6": "N"
+}

--- a/GoodWin.Gui/Presets/qwer.json
+++ b/GoodWin.Gui/Presets/qwer.json
@@ -1,0 +1,14 @@
+{
+  "Ability1": "Q",
+  "Ability2": "W",
+  "Ability3": "E",
+  "Ability4": "R",
+  "Ability5": "D",
+  "Ability6": "F",
+  "Item1": "Z",
+  "Item2": "X",
+  "Item3": "C",
+  "Item4": "V",
+  "Item5": "B",
+  "Item6": "N"
+}

--- a/GoodWin.Gui/Views/SettingsView.xaml
+++ b/GoodWin.Gui/Views/SettingsView.xaml
@@ -13,7 +13,11 @@
         </Grid.RowDefinitions>
         <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
             <Button Content="Reload" Command="{Binding ReloadCommand}" Margin="0,0,5,0" />
-            <Button Content="Save" Command="{Binding SaveCommand}" />
+            <Button Content="Save" Command="{Binding SaveCommand}" Margin="0,0,5,0" />
+            <Button Content="Export" Command="{Binding ExportCommand}" Margin="0,0,5,0" />
+            <Button Content="Import" Command="{Binding ImportCommand}" Margin="0,0,5,0" />
+            <ComboBox ItemsSource="{Binding Presets}" SelectedItem="{Binding SelectedPreset}" DisplayMemberPath="Name" Width="100" Margin="0,0,5,0" />
+            <Button Content="Apply" Command="{Binding ApplyPresetCommand}" />
         </StackPanel>
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>


### PR DESCRIPTION
## Summary
- add Export, Import and Apply preset commands to settings view
- serialize keybinds to JSON and load from JSON
- include QWER, ASDF and ESDF preset files and copy to output

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897388a4c048322a88133f2ea6e2ad6