### PR TITLE
Detach event handlers before clearing settings items

### DIFF
--- a/GoodWin.Gui/ViewModels/SettingsViewModel.cs
+++ b/GoodWin.Gui/ViewModels/SettingsViewModel.cs
@@ -52,6 +52,8 @@ namespace GoodWin.Gui.ViewModels
         private void Load()
         {
             Categories.Clear();
+            foreach (var item in _allItems)
+                item.PropertyChanged -= Item_PropertyChanged;
             _allItems.Clear();
             foreach (var item in _keybinds.Entries.Select(e => new KeybindItemViewModel(e)))
             {


### PR DESCRIPTION
## Summary
- prevent lingering PropertyChanged handlers when reloading settings by detaching them before clearing the item list

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Unable to find package Vortice.Windows)*

------
https://chatgpt.com/codex/tasks/task_e_6897444da160832287a1705705af5ffd