### PR TITLE
Add System namespace to SettingsViewModel

### DIFF
--- a/GoodWin.Gui/ViewModels/SettingsViewModel.cs
+++ b/GoodWin.Gui/ViewModels/SettingsViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;


### PR DESCRIPTION
## Summary
- add missing `System` namespace to SettingsViewModel for `Exception`, `StringComparison`, and `AppContext`

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop"; NETSDK1100: EnableWindowsTargeting needed)*

------
https://chatgpt.com/codex/tasks/task_e_68975b74ac8c83229907e8bdaccd917d