### PR TITLE
Gracefully handle absent ViGEm bus

### DIFF
--- a/GoodWin.Utils/GoodWin.Utils.csproj
+++ b/GoodWin.Utils/GoodWin.Utils.csproj
@@ -13,7 +13,8 @@
     <PackageReference Include="H.InputSimulator" Version="1.5.0" />
     <PackageReference Include="System.Windows.Extensions" Version="9.0.7" />
     <PackageReference Include="Nefarius.ViGEm.Client" Version="1.21.256" />
-        <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" />
     <ProjectReference Include="..\GoodWin.Core\GoodWin.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Avoid initializing ViGEm client when the ViGEm bus driver is missing
- Added service check using `ServiceController` and extra package dependency

## Testing
- `dotnet build GoodWin.Utils/GoodWin.Utils.csproj -p:EnableWindowsTargeting=true` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975dd890a08322936c244dfe7c6549