### PR TITLE
Explicitly set thread apartment state in utilities

### DIFF
--- a/GoodWin.Utils/InputHookHost.cs
+++ b/GoodWin.Utils/InputHookHost.cs
@@ -88,9 +88,9 @@ namespace GoodWin.Utils
             })
             {
                 IsBackground = true,
-                ApartmentState = ApartmentState.STA,
                 Name = "InputHookHostThread"
             };
+            _thread.SetApartmentState(ApartmentState.STA);
             _thread.Start();
         }
 

--- a/GoodWin.Utils/OverlayWindow.cs
+++ b/GoodWin.Utils/OverlayWindow.cs
@@ -52,10 +52,10 @@ namespace GoodWin.Utils
                     })
                     {
                         IsBackground = true,
-                        Name = "OverlayWindowThread",
-                        ApartmentState = ApartmentState.STA
+                        Name = "OverlayWindowThread"
                     };
 
+                    thread.SetApartmentState(ApartmentState.STA);
                     thread.Start();
                     ready.WaitOne();
 


### PR DESCRIPTION
## Summary
- use SetApartmentState(ApartmentState.STA) before starting threads in InputHookHost and OverlayWindow

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689762e3c1208322ad6ca01949447fca