### PR TITLE
Use Microsoft.NET.Sdk for GoodWin.Gui

### DIFF
--- a/GoodWin.Gui/GoodWin.Gui.csproj
+++ b/GoodWin.Gui/GoodWin.Gui.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>


### PR DESCRIPTION
## Summary
- replace WindowsDesktop SDK with generic SDK in GoodWin.Gui project

## Testing
- `dotnet build GoodWinDebuff.sln -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897641daba0832293b3184e2e141321