### PR TITLE
Handle nullability warnings across modules

### DIFF
--- a/GoodWin.Core/DebuffScheduler.cs
+++ b/GoodWin.Core/DebuffScheduler.cs
@@ -20,7 +20,7 @@ namespace GoodWin.Core
     public class DebuffScheduler
     {
         // Событие, возникающее при наступлении времени выбора нового дебаффа.
-        public event EventHandler DebuffSelectionPending;
+        public event EventHandler? DebuffSelectionPending;
 
         private readonly Random _random = new Random();
 

--- a/GoodWin.Debuffs.Hard/RainbowDebuff.cs
+++ b/GoodWin.Debuffs.Hard/RainbowDebuff.cs
@@ -79,8 +79,16 @@ public class RainbowDebuff : DebuffBase, IOverlayDebuff
             _hwnd = Native.CreateWindow();
 
             // Device + swap chain
-            DXGI.CreateDXGIFactory1(out IDXGIFactory2 factory).CheckError();
-            D3D11.D3D11CreateDevice(null, DriverType.Hardware, DeviceCreationFlags.BgraSupport, null, out _device).CheckError();
+            DXGI.CreateDXGIFactory1(out IDXGIFactory2? factoryTmp).CheckError();
+            var factory = factoryTmp ?? throw new InvalidOperationException("DXGI factory creation failed");
+
+            D3D11.D3D11CreateDevice(
+                adapter: null,
+                DriverType.Hardware,
+                DeviceCreationFlags.BgraSupport,
+                featureLevels: null,
+                out ID3D11Device? deviceTmp).CheckError();
+            _device = deviceTmp ?? throw new InvalidOperationException("Failed to create D3D11 device");
             _context = _device.ImmediateContext;
 
             int width = Native.GetSystemMetrics(0);
@@ -161,7 +169,7 @@ public class RainbowDebuff : DebuffBase, IOverlayDebuff
 
                     hue += 0.01f;
                     var data = new HueConstant { Hue = hue };
-                    _context.UpdateSubresource(ref data, _cbuffer);
+                    _context.UpdateSubresource(in data, _cbuffer);
 
                     _context.OMSetRenderTargets(_rtv);
                     _context.ClearRenderTargetView(_rtv, new Color4(0, 0, 0, 0));

--- a/GoodWin.Gui/ViewModels/MainViewModel.cs
+++ b/GoodWin.Gui/ViewModels/MainViewModel.cs
@@ -288,8 +288,10 @@ namespace GoodWin.Gui.ViewModels
             OnPropertyChanged(nameof(AnyCategoryEnabled));
         }
 
-        private async Task RunManualDebuff(IDebuff debuff)
+        private async Task RunManualDebuff(IDebuff? debuff)
         {
+            if (debuff is null) return;
+
             var notify = new DebuffNotificationWindow(debuff.Name, "Описание дебаффа");
             notify.Show();
             await Task.Delay(3000);
@@ -331,10 +333,12 @@ namespace GoodWin.Gui.ViewModels
         private void ToggleHeroTracking(bool enabled)
         {
             if (enabled)
-            {
-                var capture = new ScreenCaptureService(60);
-                var bounds = System.Windows.Forms.Screen.PrimaryScreen.Bounds;
-                var minimapRect = new System.Drawing.Rectangle(0, bounds.Height - 256, 256, 256);
+                {
+                    var capture = new ScreenCaptureService(60);
+                    var screen = System.Windows.Forms.Screen.PrimaryScreen;
+                    if (screen is null) return;
+                    var bounds = screen.Bounds;
+                    var minimapRect = new System.Drawing.Rectangle(0, bounds.Height - 256, 256, 256);
                 _heroDetector = new HeroDetector(capture, minimapRect);
                 _heroDetector.HeroPositionUpdated += pos =>
                 {

--- a/GoodWin.Tracker/ScreenCaptureService.cs
+++ b/GoodWin.Tracker/ScreenCaptureService.cs
@@ -40,7 +40,9 @@ namespace GoodWin.Tracker
         {
             try
             {
-                var bounds = Screen.PrimaryScreen.Bounds;
+                var screen = Screen.PrimaryScreen;
+                if (screen is null) return;
+                var bounds = screen.Bounds;
                 using var bmp = new Bitmap(bounds.Width, bounds.Height);
                 using var g = Graphics.FromImage(bmp);
                 g.CopyFromScreen(bounds.Location, Point.Empty, bounds.Size);

--- a/GoodWin.Utils/CommandExecutor.cs
+++ b/GoodWin.Utils/CommandExecutor.cs
@@ -10,7 +10,7 @@ namespace GoodWin.Utils
         static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 
         [DllImport("user32.dll")]
-        static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+        static extern IntPtr FindWindow(string lpClassName, string? lpWindowName);
 
         [DllImport("user32.dll")]
         static extern bool SetForegroundWindow(IntPtr hWnd);

--- a/GoodWin.Utils/InputHookHost.cs
+++ b/GoodWin.Utils/InputHookHost.cs
@@ -331,7 +331,13 @@ namespace GoodWin.Utils
                             _lastMousePt = data.pt;
                             _hasLastPt = true;
                         }
-                        int screenHeight = Screen.PrimaryScreen.Bounds.Height;
+                        var screen = Screen.PrimaryScreen;
+                        if (screen == null)
+                        {
+                            _lastMousePt = data.pt;
+                            return CallNextHookEx(_mouseHook, nCode, wParam, lParam);
+                        }
+                        int screenHeight = screen.Bounds.Height;
                         if (data.pt.y <= 0 || data.pt.y >= screenHeight - 1)
                         {
                             _lastMousePt = data.pt;


### PR DESCRIPTION
## Summary
- guard Screen.PrimaryScreen usages and handle missing screens
- make manual debuff command accept nullable parameter
- ensure DirectX resources are created with null checks and use `in` parameter for updates
- allow DebuffScheduler event to be nullable and fix interop signatures

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*


------
https://chatgpt.com/codex/tasks/task_e_6897668df7488322a629dd7caf34f4c4